### PR TITLE
#11 feat/guild user card component2

### DIFF
--- a/public/crown.svg
+++ b/public/crown.svg
@@ -1,0 +1,5 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="icon/crown">
+<path id="Vector" d="M2.5 10H9.5M1 2L2.5 8H9.5L11 2L8 5.5L6 2L4 5.5L1 2Z" stroke="white" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/public/star.svg
+++ b/public/star.svg
@@ -1,0 +1,10 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="icon/star" clip-path="url(#clip0_457_10708)">
+<path id="Vector" d="M6 1L7.545 4.13L11 4.635L8.5 7.07L9.09 10.51L6 8.885L2.91 10.51L3.5 7.07L1 4.635L4.455 4.13L6 1Z" stroke="white" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_457_10708">
+<rect width="12" height="12" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,0 +1,18 @@
+
+// import PopularCard from "@/components/game/PopularCard";
+// import PickCard from "@/components/game/PickCard";
+// import SteamCard from "@/components/game/SteamCard";
+
+// import Chat from "@/components/guildUser/Chat";
+// import GuildUser from "@/components/guildUser/GuildUser";
+// import GuildUserCard from "@/components/guildUser/GuildUserCard";
+
+
+export default function Game() {
+
+  return (
+    <>
+
+    </>
+  );
+}

--- a/src/components/guildUser/Chat.tsx
+++ b/src/components/guildUser/Chat.tsx
@@ -1,5 +1,5 @@
 import { guildUser } from '@/types/guildUser';
-import { Avatar } from '../ui/avatar';
+import { Avatar, AvatarImage } from '../ui/avatar';
 
 type chatProps = {
   data: guildUser;
@@ -13,8 +13,9 @@ export default function Chat(props: chatProps) {
   return (
     <>
       <div className={`flex ${isSender ? 'justify-start flex-row' : 'flex-row-reverse'} gap-5 items-center`}>
-        {<Avatar className="bg-neutral-400 w-16 h-16" />}
-
+        <Avatar className="bg-neutral-400 w-16 h-16">
+          <AvatarImage src={data.image} />
+        </Avatar>
         <div className={`box-content bg-neutral-200 rounded-lg px-5 py-2 ${isSender ? 'mr-3' : 'ml-3'}`}>
           <div className="flex gap-1">
             {isSender && (

--- a/src/components/guildUser/Chat.tsx
+++ b/src/components/guildUser/Chat.tsx
@@ -1,22 +1,28 @@
 import { guildUser } from '@/types/guildUser';
 import { Avatar } from '../ui/avatar';
 
-type chatprops = {
+type chatProps = {
   data: guildUser;
   isSender: boolean;
   message: string;
 }
 
-export default function Chat({data, isSender, message}: chatprops) {
+export default function Chat(props: chatProps) {
+  const {data, isSender, message} = props
+
   return (
     <>
-      <div className={`flex ${isSender ? 'flex-row-reverse' : 'justify-start flex-row'} gap-5 items-center`}>
+      <div className={`flex ${isSender ? 'justify-start flex-row' : 'flex-row-reverse'} gap-5 items-center`}>
         {<Avatar className="bg-neutral-400 w-16 h-16" />}
 
-        <div className={`box-content bg-white rounded-lg px-5 py-2 ${isSender ? 'mr-3' : 'ml-3'}`}>
-          <div className="flex gap-1 ">
-            <p className="font-suit text-xs text-neutral-400 font-normal">{data.userTitle}</p>
-            <p className="font-suit text-xs text-sky-700 font-bold">{data.name}</p>
+        <div className={`box-content bg-neutral-200 rounded-lg px-5 py-2 ${isSender ? 'mr-3' : 'ml-3'}`}>
+          <div className="flex gap-1">
+            {isSender && (
+              <div>
+                <p className="font-suit text-xs text-neutral-400 font-normal">{data.userTitle}</p>
+                <p className="font-suit text-xs text-purple-600 font-bold">{data.name}</p>
+              </div>
+            )}
           </div>
 
           <p className="font-suit text-base font-normal">{message}</p>

--- a/src/components/guildUser/Chat.tsx
+++ b/src/components/guildUser/Chat.tsx
@@ -1,19 +1,25 @@
 import { guildUser } from '@/types/guildUser';
 import { Avatar } from '../ui/avatar';
 
-export default function Chat(props: guildUser) {
+type chatprops = {
+  data: guildUser;
+  isSender: boolean;
+  message: string;
+}
+
+export default function Chat({data, isSender, message}: chatprops) {
   return (
     <>
-      <div className="flex gap-5">
-        <Avatar className="bg-neutral-400 aspect-square" />
+      <div className={`flex ${isSender ? 'flex-row-reverse' : 'justify-start flex-row'} gap-5 items-center`}>
+        {<Avatar className="bg-neutral-400 w-16 h-16" />}
 
-        <div className='box-content bg-white rounded-lg px-5 py-2'>
+        <div className={`box-content bg-white rounded-lg px-5 py-2 ${isSender ? 'mr-3' : 'ml-3'}`}>
           <div className="flex gap-1 ">
-            <p className="font-suit text-xs text-neutral-400 font-normal">{props.userTitle}</p>
-            <p className="font-suit text-xs text-sky-700 font-bold">{props.name}</p>
+            <p className="font-suit text-xs text-neutral-400 font-normal">{data.userTitle}</p>
+            <p className="font-suit text-xs text-sky-700 font-bold">{data.name}</p>
           </div>
 
-          <p className="font-suit text-base font-normal">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+          <p className="font-suit text-base font-normal">{message}</p>
         </div>
       </div>
     </>

--- a/src/components/guildUser/Chat.tsx
+++ b/src/components/guildUser/Chat.tsx
@@ -1,0 +1,16 @@
+import { guildUser } from "@/types/guildUser";
+
+
+export default function Chat(props: guildUser) {
+  return (
+    <>
+      <div className="flex gap-[4px] ">
+        <p className="font-suit text-[12px] text-neutral-400 font-normal">{props.userTitle}</p>
+        <p className="font-suit text-[12px] text-sky-700 font-bold">{props.name}</p>
+      </div>
+
+        <p className="font-suit text-[16px] font-normal">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+    </>
+  );
+}
+

--- a/src/components/guildUser/Chat.tsx
+++ b/src/components/guildUser/Chat.tsx
@@ -1,16 +1,21 @@
-import { guildUser } from "@/types/guildUser";
-
+import { guildUser } from '@/types/guildUser';
+import { Avatar } from '../ui/avatar';
 
 export default function Chat(props: guildUser) {
   return (
     <>
-      <div className="flex gap-[4px] ">
-        <p className="font-suit text-[12px] text-neutral-400 font-normal">{props.userTitle}</p>
-        <p className="font-suit text-[12px] text-sky-700 font-bold">{props.name}</p>
-      </div>
+      <div className="flex gap-5">
+        <Avatar className="bg-neutral-400 aspect-square" />
 
-        <p className="font-suit text-[16px] font-normal">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+        <div className='box-content bg-white rounded-lg px-5 py-2'>
+          <div className="flex gap-1 ">
+            <p className="font-suit text-xs text-neutral-400 font-normal">{props.userTitle}</p>
+            <p className="font-suit text-xs text-sky-700 font-bold">{props.name}</p>
+          </div>
+
+          <p className="font-suit text-base font-normal">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+        </div>
+      </div>
     </>
   );
 }
-

--- a/src/components/guildUser/GuildUser.tsx
+++ b/src/components/guildUser/GuildUser.tsx
@@ -1,16 +1,21 @@
 import { Avatar } from '@/components/ui/avatar';
 import { guildUser } from '@/types/guildUser';
+import { useMemo } from 'react';
 
 type guildUserProps = {
   data: guildUser;
   lastDate: string;
   postNum: number;
-  showBorder?: boolean;
+  index: number;
+  total: number;
   // avatarClassName?: string;
 };
 
-export default function GuildUser({ data, lastDate, postNum, showBorder = true }: guildUserProps) {
-// export default function GuildUser({ data, lastDate, postNum, showBorder = true, avatarClassName="w-full" }: guildUserProps) {
+export default function GuildUser(props: guildUserProps) {
+
+  const { data, lastDate, postNum, index, total } = props;
+  const isList = useMemo(() => index === total - 1, [index, total]);
+
   return (
     <>
       <div className="flex gap-6 py-8">
@@ -40,7 +45,7 @@ export default function GuildUser({ data, lastDate, postNum, showBorder = true }
         </div>
       </div>
 
-      {showBorder && <div className="border-b border-neutral-200"></div>}
+      {!isList && <div className="border-b border-neutral-200"></div>}
     </>
   );
 }

--- a/src/components/guildUser/GuildUser.tsx
+++ b/src/components/guildUser/GuildUser.tsx
@@ -11,33 +11,34 @@ export default function GuildUser(props: guildUserProps) {
 
   return (
     <>
-      <div className="flex gap-[24px] w-[1275px] h-[158px] py-[32px]">
-        <Avatar className="bg-neutral-400 w-[64px] h-[64px]" />
+      <div className="flex gap-6 py-8">
+        <Avatar className="bg-neutral-400 aspect-square" />
 
-        <div className="w-[1068px]">
-          <p className="font-suit text-[24px] font-bold">{props.data.name}</p>
+        <div className="w-full">
+          <p className="font-suit text-2xl font-bold">{props.data.name}</p>
 
           <div className="flex gap-5">
             <div className="flex">
-              <p className="font-suit text-[16px] font-medium">길드 가입일 : </p> &nbsp;
-              <p className="font-suit text-[16px] font-medium text-neutral-500">{props.data.guildJoinDate}</p>
+              <p className="font-suit text-base font-medium">길드 가입일 : </p> &nbsp;
+              <p className="font-suit text-base font-medium text-neutral-500">{props.data.guildJoinDate}</p>
             </div>
 
             <div className="flex">
-              <p className="font-suit text-[16px] font-medium">마지막 접속 일자 : </p> &nbsp;
-              <p className="font-suit text-[16px] font-medium text-neutral-500">{props.lastDate}</p>
+              <p className="font-suit text-base font-medium">마지막 접속 일자 : </p> &nbsp;
+              <p className="font-suit text-base font-medium text-neutral-500">{props.lastDate}</p>
             </div>
           </div>
 
-            <p className="font-suit text-[16px] font-medium">전체 글 갯수 : {props.postNum}개</p>
+            <p className="font-suit text-base font-medium">전체 글 갯수 : {props.postNum}개</p>
         </div>
 
-        <div className="flex gap-2">
-        <div className="font-suit text-[16px] font-medium">퇴출</div>
-        <div className="font-suit text-[16px] font-medium">권한변경</div>
+        <div className="flex gap-3">
+          <div className="font-suit text-base font-medium">권한변경</div>
+          <div className="font-suit text-base font-medium">퇴출</div>
         </div>
         
       </div>
+      <div className="border-b border-neutral-200"></div> 
     </>
   );
 }

--- a/src/components/guildUser/GuildUser.tsx
+++ b/src/components/guildUser/GuildUser.tsx
@@ -1,0 +1,43 @@
+import { Avatar } from "@/components/ui/avatar";
+import { guildUser } from "@/types/guildUser";
+
+type guildUserProps = {
+  data: guildUser;
+  lastDate: string;
+  postNum: number;
+}
+
+export default function GuildUser(props: guildUserProps) {
+
+  return (
+    <>
+      <div className="flex gap-[24px] w-[1275px] h-[158px] py-[32px]">
+        <Avatar className="bg-neutral-400 w-[64px] h-[64px]" />
+
+        <div className="w-[1068px]">
+          <p className="font-suit text-[24px] font-bold">{props.data.name}</p>
+
+          <div className="flex gap-5">
+            <div className="flex">
+              <p className="font-suit text-[16px] font-medium">길드 가입일 : </p> &nbsp;
+              <p className="font-suit text-[16px] font-medium text-neutral-500">{props.data.guildJoinDate}</p>
+            </div>
+
+            <div className="flex">
+              <p className="font-suit text-[16px] font-medium">마지막 접속 일자 : </p> &nbsp;
+              <p className="font-suit text-[16px] font-medium text-neutral-500">{props.lastDate}</p>
+            </div>
+          </div>
+
+            <p className="font-suit text-[16px] font-medium">전체 글 갯수 : {props.postNum}개</p>
+        </div>
+
+        <div className="flex gap-2">
+        <div className="font-suit text-[16px] font-medium">퇴출</div>
+        <div className="font-suit text-[16px] font-medium">권한변경</div>
+        </div>
+        
+      </div>
+    </>
+  );
+}

--- a/src/components/guildUser/GuildUser.tsx
+++ b/src/components/guildUser/GuildUser.tsx
@@ -1,4 +1,4 @@
-import { Avatar } from '@/components/ui/avatar';
+import { Avatar, AvatarImage } from '@/components/ui/avatar';
 import { guildUser } from '@/types/guildUser';
 import { useMemo } from 'react';
 
@@ -19,7 +19,9 @@ export default function GuildUser(props: guildUserProps) {
   return (
     <>
       <div className="flex gap-6 py-8">
-        <Avatar className="bg-neutral-400 w-16 h-16" />
+        <Avatar className="bg-neutral-400 w-16 h-16">
+          <AvatarImage src={data.image} />
+        </Avatar>
 
         <div className="w-full">
           <p className="font-suit text-2xl font-bold">{data.name}</p>

--- a/src/components/guildUser/GuildUser.tsx
+++ b/src/components/guildUser/GuildUser.tsx
@@ -1,44 +1,46 @@
-import { Avatar } from "@/components/ui/avatar";
-import { guildUser } from "@/types/guildUser";
+import { Avatar } from '@/components/ui/avatar';
+import { guildUser } from '@/types/guildUser';
 
 type guildUserProps = {
   data: guildUser;
   lastDate: string;
   postNum: number;
-}
+  showBorder?: boolean;
+  // avatarClassName?: string;
+};
 
-export default function GuildUser(props: guildUserProps) {
-
+export default function GuildUser({ data, lastDate, postNum, showBorder = true }: guildUserProps) {
+// export default function GuildUser({ data, lastDate, postNum, showBorder = true, avatarClassName="w-full" }: guildUserProps) {
   return (
     <>
       <div className="flex gap-6 py-8">
-        <Avatar className="bg-neutral-400 aspect-square" />
+        <Avatar className="bg-neutral-400 w-16 h-16" />
 
         <div className="w-full">
-          <p className="font-suit text-2xl font-bold">{props.data.name}</p>
+          <p className="font-suit text-2xl font-bold">{data.name}</p>
 
           <div className="flex gap-5">
             <div className="flex">
               <p className="font-suit text-base font-medium">길드 가입일 : </p> &nbsp;
-              <p className="font-suit text-base font-medium text-neutral-500">{props.data.guildJoinDate}</p>
+              <p className="font-suit text-base font-medium text-neutral-500">{data.guildJoinDate}</p>
             </div>
 
             <div className="flex">
               <p className="font-suit text-base font-medium">마지막 접속 일자 : </p> &nbsp;
-              <p className="font-suit text-base font-medium text-neutral-500">{props.lastDate}</p>
+              <p className="font-suit text-base font-medium text-neutral-500">{lastDate}</p>
             </div>
           </div>
 
-            <p className="font-suit text-base font-medium">전체 글 갯수 : {props.postNum}개</p>
+          <p className="font-suit text-base font-medium">전체 글 갯수 : {postNum}개</p>
         </div>
 
         <div className="flex gap-3">
-          <div className="font-suit text-base font-medium">권한변경</div>
-          <div className="font-suit text-base font-medium">퇴출</div>
+          <div className="font-suit text-base font-medium whitespace-nowrap flex-shrink-0 min-w-fit">권한변경</div>
+          <div className="font-suit text-base font-medium whitespace-nowrap flex-shrink-0 min-w-fit">퇴출</div>
         </div>
-        
       </div>
-      <div className="border-b border-neutral-200"></div> 
+
+      {showBorder && <div className="border-b border-neutral-200"></div>}
     </>
   );
 }

--- a/src/components/guildUser/GuildUserCard.tsx
+++ b/src/components/guildUser/GuildUserCard.tsx
@@ -1,4 +1,4 @@
-import { Avatar } from "@/components/ui/avatar";
+import { Avatar, AvatarImage } from "@/components/ui/avatar";
 import { guildUser } from "@/types/guildUser";
 
 type guildUserCardProps = {
@@ -39,7 +39,9 @@ export default function GuildUserCard(props: guildUserCardProps) {
       <div className="box-content rounded-lg border border-neutral-300 px-6 py-8">
         <div className="flex gap-5">
           <div className="w-16 h-16 aspect-square relative ">
-            <Avatar className="bg-neutral-400 w-16 h-16" />
+            <Avatar className="bg-neutral-400 w-16 h-16">
+              <AvatarImage src={data.image} />
+            </Avatar>
             {badge}
 
             {/* <div className="bg-amber-300 rounded-full w-5 h-5 absolute bottom-0 right-0">

--- a/src/components/guildUser/GuildUserCard.tsx
+++ b/src/components/guildUser/GuildUserCard.tsx
@@ -1,17 +1,24 @@
 import { Avatar } from "@/components/ui/avatar";
 import { guildUser } from "@/types/guildUser";
 
-export default function GuildUserCard(props: guildUser) {
+type guildUserCardProps = {
+  data: guildUser;
+  // avatarClassName: string;
+}
 
+export default function GuildUserCard({data}: guildUserCardProps) {
+// export default function GuildUserCard({data, avatarClassName="w-full"}: guildUserCardProps) {
   return (
     <>
-      <div className="box-content w-full rounded-lg border border-neutral-300 px-6 py-8">
-        <div className="flex">
-          <Avatar className="bg-neutral-400 aspect-square" />
-          <div className="ml-5">
-            <p className="font-suit text-sm font-normal text-neutral-500">{props.userTitle}</p>
-            <p className="font-suit text-xl font-medium">{props.name}</p>
-              <p className="font-suit text-sm font-normal text-neutral-500">가입일 : {props.guildJoinDate}</p>
+      <div className="box-content rounded-lg border border-neutral-300 px-6 py-8">
+        <div className="flex gap-5">
+          <Avatar className="bg-neutral-400 w-16 h-16" />
+          <div className="">
+            {data.userTitle && <p className="font-suit text-sm font-normal text-neutral-500">{data.userTitle}</p>}
+            <p className="font-suit text-xl font-medium">{data.name}</p>
+            {data.guildJoinDate && (
+              <p className="font-suit text-sm font-normal text-neutral-500">가입일 : {data.guildJoinDate}</p>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/guildUser/GuildUserCard.tsx
+++ b/src/components/guildUser/GuildUserCard.tsx
@@ -5,13 +5,13 @@ export default function GuildUserCard(props: guildUser) {
 
   return (
     <>
-      <div className="box-content w-[363px] h-[66px] rounded-lg border border-neutral-300 px-[24px] py-[32px]">
+      <div className="box-content w-full rounded-lg border border-neutral-300 px-6 py-8">
         <div className="flex">
-          <Avatar className="w-[60px] h-[60px] bg-neutral-400" />
+          <Avatar className="bg-neutral-400 aspect-square" />
           <div className="ml-5">
-            <p className="font-suit text-[14px] leading-[17px] font-normal text-neutral-500">{props.userTitle}</p>
-            <p className="font-suit text-[20px] leading-[28px] font-medium">{props.name}</p>
-              <p className="font-suit text-[14px] leading-[17px] font-normal text-neutral-500">가입일 : {props.guildJoinDate}</p>
+            <p className="font-suit text-sm font-normal text-neutral-500">{props.userTitle}</p>
+            <p className="font-suit text-xl font-medium">{props.name}</p>
+              <p className="font-suit text-sm font-normal text-neutral-500">가입일 : {props.guildJoinDate}</p>
           </div>
         </div>
       </div>

--- a/src/components/guildUser/GuildUserCard.tsx
+++ b/src/components/guildUser/GuildUserCard.tsx
@@ -3,16 +3,48 @@ import { guildUser } from "@/types/guildUser";
 
 type guildUserCardProps = {
   data: guildUser;
+  memberLevel: string; // leader, manager, user
   // avatarClassName: string;
-}
+};
 
-export default function GuildUserCard({data}: guildUserCardProps) {
-// export default function GuildUserCard({data, avatarClassName="w-full"}: guildUserCardProps) {
+
+
+export default function GuildUserCard(props: guildUserCardProps) {
+  
+  const { data, memberLevel } = props;
+  let badge;
+  
+  switch (memberLevel) {
+    case 'leader':
+      badge = (
+        <div className="bg-amber-300 rounded-full w-5 h-5 absolute bottom-0 right-0">
+          <img src="crown.svg" className="p-1" />
+        </div>
+      );
+      break;
+
+    case 'manager':
+      badge = (
+        <div className="bg-red-300 rounded-full w-5 h-5 absolute bottom-0 right-0">
+          <img src="star.svg" className="p-1" />
+        </div>
+      );
+      break;
+    case 'user':
+      badge = <div></div>;
+  }
+
   return (
     <>
       <div className="box-content rounded-lg border border-neutral-300 px-6 py-8">
         <div className="flex gap-5">
-          <Avatar className="bg-neutral-400 w-16 h-16" />
+          <div className="w-16 h-16 aspect-square relative ">
+            <Avatar className="bg-neutral-400 w-16 h-16" />
+            {badge}
+
+            {/* <div className="bg-amber-300 rounded-full w-5 h-5 absolute bottom-0 right-0">
+            </div> */}
+          </div>
           <div className="">
             {data.userTitle && <p className="font-suit text-sm font-normal text-neutral-500">{data.userTitle}</p>}
             <p className="font-suit text-xl font-medium">{data.name}</p>

--- a/src/components/guildUser/GuildUserCard.tsx
+++ b/src/components/guildUser/GuildUserCard.tsx
@@ -1,0 +1,20 @@
+import { Avatar } from "@/components/ui/avatar";
+import { guildUser } from "@/types/guildUser";
+
+export default function GuildUserCard(props: guildUser) {
+
+  return (
+    <>
+      <div className="box-content w-[363px] h-[66px] rounded-lg border border-neutral-300 px-[24px] py-[32px]">
+        <div className="flex">
+          <Avatar className="w-[60px] h-[60px] bg-neutral-400" />
+          <div className="ml-5">
+            <p className="font-suit text-[14px] leading-[17px] font-normal text-neutral-500">{props.userTitle}</p>
+            <p className="font-suit text-[20px] leading-[28px] font-medium">{props.name}</p>
+              <p className="font-suit text-[14px] leading-[17px] font-normal text-neutral-500">가입일 : {props.guildJoinDate}</p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/types/guildUser.ts
+++ b/src/types/guildUser.ts
@@ -1,0 +1,5 @@
+export type guildUser = {
+  userTitle?: string;
+  name: string;
+  guildJoinDate?: string;
+}

--- a/src/types/guildUser.ts
+++ b/src/types/guildUser.ts
@@ -2,4 +2,5 @@ export type guildUser = {
   userTitle?: string;
   name: string;
   guildJoinDate?: string;
+  image: string;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#11 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

길드 유저 카드 컴포넌트 작업했습니다.


### 스크린샷 (선택)

GuildUserCard
<img width="803" alt="스크린샷 2025-04-01 12 27 07" src="https://github.com/user-attachments/assets/73ca66e4-d6b0-4e48-9824-096b91de0806" />

Chat
<img width="803" alt="스크린샷 2025-04-01 12 27 13" src="https://github.com/user-attachments/assets/f3a642d6-54f7-4ecc-ba2d-191582aaa649" />

GuildUser
<img width="1428" alt="스크린샷 2025-04-01 12 27 22" src="https://github.com/user-attachments/assets/04798300-328e-410c-b868-8de33937f2a7" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

Chat 컴포넌트의 경우
사용하지 않을 수 있다고 하셨는데
만들었어서 일단 같이 commit 했습니다.
사용 안하게 되면 그때 빼도 될 것 같습니다.