### PR TITLE
Feat: party detail left section components

### DIFF
--- a/src/app/party/components/AuthorInfo.tsx
+++ b/src/app/party/components/AuthorInfo.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@/components/ui/button';
+import { Avatar } from '@radix-ui/react-avatar';
+
+type User = {
+  profile_img: string;
+  title: string;
+  username: string;
+};
+
+interface AuthorInfoProps {
+  data: User;
+}
+
+export default function AuthorInfo({ data }: AuthorInfoProps) {
+  return (
+    <div className="flex gap-6 justify-between items-center w-full">
+      <Avatar
+        style={{
+          backgroundImage: `url(${data.profile_img})`,
+        }}
+        className="bg-cover bg-center size-20 rounded-full shrink-0"
+      />
+      <div className="flex flex-col w-full">
+        <div className="text-base text-neutral-900">{data.title}</div>
+        <div className="text-xl text-neutral-900 font-bold">{data.username}님의 파티</div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/party/components/AuthorInfo.tsx
+++ b/src/app/party/components/AuthorInfo.tsx
@@ -1,12 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { Avatar } from '@radix-ui/react-avatar';
 
-type User = {
-  profile_img: string;
-  title: string;
-  username: string;
-};
-
 interface AuthorInfoProps {
   data: User;
 }

--- a/src/app/party/components/UserApprove.tsx
+++ b/src/app/party/components/UserApprove.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Avatar } from '@radix-ui/react-avatar';
+
+interface UserApproveProps {
+  data: User;
+  onApprove: () => void;
+  onReject: () => void;
+}
+
+export default function UserApprove({ data, onApprove, onReject }: UserApproveProps) {
+  return (
+    <div className="flex justify-between items-center w-full">
+      <div className="flex gap-3">
+        <Avatar
+          style={{
+            backgroundImage: `url(${data.profile_img})`,
+          }}
+          className="bg-cover bg-center size-12 rounded-full shrink-0"
+        />
+        <div className="flex flex-col">
+          <div className="text-sm text-neutral-500 leading-5">{data.title}</div>
+          <div className="text-lg text-neutral-900 font-semibold">{data.username}</div>
+        </div>
+      </div>
+
+      <div className="flex gap-2 shrink-0">
+        <Button onClick={() => onApprove()} className="bg-neutral-900 text-sm px-4">
+          승인
+        </Button>
+        <Button onClick={() => onReject()} variant={'outline'} className="border-neutral-900 text-neutral-900 text-sm">
+          거부
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,5 @@
+interface User {
+  profile_img: string;
+  title: string;
+  username: string;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#22 

## 📝작업 내용

**UserApprove**
- props로 `data, onApprove, onReject` 를 받습니다.
- `data`는 유저 정보이고, `onApprove`, `onReject` 는 각각 '승인', '거부'가 클릭 되었을 때 실행될 콜백 함수입니다.

![스크린샷 2025-04-01 오후 4 35 04](https://github.com/user-attachments/assets/22e7eec8-90ab-4c0d-8192-c1d70784afad)

**AuthorInfo**
- prop으로 `data`(유저 정보)만 전달해주면 됩니다.
- 너비는 부모요소에 맞춰지게 해두었습니다.
- 아래의 사진처럼 username이 부모요소의 크기보다 길 경우에는 2줄로 표시됩니다.

![스크린샷 2025-04-01 오후 4 35 12](https://github.com/user-attachments/assets/c82dce10-1aaf-4ed6-852c-2df32bc21a01)
![스크린샷 2025-04-01 오후 4 50 22](https://github.com/user-attachments/assets/6b946099-7fcb-44e4-ac83-5bf731fed940)


### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
