### PR TITLE
Feat: party log component

### DIFF
--- a/src/components/party/PartyCard.tsx
+++ b/src/components/party/PartyCard.tsx
@@ -2,6 +2,7 @@ import { Party } from '@/types/party';
 import { Avatar } from '../ui/avatar';
 import Tag from '../common/Tag';
 import { Skeleton } from '../ui/skeleton';
+import formatDate from '@/utils/formatDate';
 
 interface PartyCardProps {
   data: Party;
@@ -103,15 +104,4 @@ function getRemainingHours(targetDate: Date) {
   const timeDifference = targetTime - currentTime;
 
   return timeDifference / (1000 * 60 * 60);
-}
-
-// 날짜 포맷팅 함수
-function formatDate(targetDate: Date) {
-  return targetDate.toLocaleString('ko-KR', {
-    month: 'long',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  });
 }

--- a/src/components/party/PartyLogCard.tsx
+++ b/src/components/party/PartyLogCard.tsx
@@ -1,18 +1,19 @@
 'use client';
+
 import { Party } from '@/types/party';
 import Tag from '../common/Tag';
 import { Skeleton } from '../ui/skeleton';
 import { Button } from '../ui/button';
 import formatDate from '@/utils/formatDate';
+import { useRouter } from 'next/navigation';
 
 interface PartyCardProps {
   data: Party;
-  onBtnClick: () => void;
 }
 
 export function PartyLogCardSkeleton() {
   return (
-    <div className="flex flex-col gap-4 p-5 w-[410px] border-2 border-neutral-300 rounded-xl">
+    <div className="flex flex-col gap-4 p-5 w-[410px] border-[1px] border-neutral-300 rounded-xl">
       <Skeleton className="h-[160px] rounded-xl" />
       <div className="flex flex-col gap-1">
         <Skeleton className="h-8 rounded-sm w-1/2" />
@@ -30,7 +31,11 @@ export function PartyLogCardSkeleton() {
   );
 }
 
-export default function PartyLogCard({ data, onBtnClick: onCardClick }: PartyCardProps) {
+export default function PartyLogCard({ data }: PartyCardProps) {
+  const router = useRouter();
+  const handleClick = () => {
+    router.push('/');
+  };
   return (
     <div className="flex flex-col gap-4 p-5 w-[410px] rounded-xl bg-white border-[1px] border-neutral-300 cursor-pointer">
       <div
@@ -55,7 +60,7 @@ export default function PartyLogCard({ data, onBtnClick: onCardClick }: PartyCar
           ))}
         </div>
       </div>
-      <Button className="text-lg h-10" onClick={onCardClick}>
+      <Button className="text-lg h-10" onClick={handleClick}>
         파티 로그 확인
       </Button>
     </div>

--- a/src/components/party/PartyLogCard.tsx
+++ b/src/components/party/PartyLogCard.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { Party } from '@/types/party';
 import Tag from '../common/Tag';
 import { Skeleton } from '../ui/skeleton';
@@ -6,6 +7,7 @@ import formatDate from '@/utils/formatDate';
 
 interface PartyCardProps {
   data: Party;
+  onCardClick: () => void;
 }
 
 export function PartyLogCardSkeleton() {
@@ -31,7 +33,7 @@ export function PartyLogCardSkeleton() {
   );
 }
 
-export default function PartyLogCard({ data }: PartyCardProps) {
+export default function PartyLogCard({ data, onCardClick }: PartyCardProps) {
   return (
     <div className="flex flex-col gap-4 p-5 w-[410px] rounded-xl bg-white border-[1px] border-neutral-300 cursor-pointer">
       <div
@@ -56,7 +58,9 @@ export default function PartyLogCard({ data }: PartyCardProps) {
           ))}
         </div>
       </div>
-      <Button className="text-lg h-10">파티 로그 확인</Button>
+      <Button className="text-lg h-10" onClick={onCardClick}>
+        파티 로그 확인
+      </Button>
     </div>
   );
 }

--- a/src/components/party/PartyLogCard.tsx
+++ b/src/components/party/PartyLogCard.tsx
@@ -2,6 +2,7 @@ import { Party } from '@/types/party';
 import Tag from '../common/Tag';
 import { Skeleton } from '../ui/skeleton';
 import { Button } from '../ui/button';
+import formatDate from '@/utils/formatDate';
 
 interface PartyCardProps {
   data: Party;
@@ -58,15 +59,4 @@ export default function PartyLogCard({ data }: PartyCardProps) {
       <Button className="text-lg h-10">파티 로그 확인</Button>
     </div>
   );
-}
-
-// 날짜 포맷팅 함수
-function formatDate(targetDate: Date) {
-  return targetDate.toLocaleString('ko-KR', {
-    month: 'long',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  });
 }

--- a/src/components/party/PartyLogCard.tsx
+++ b/src/components/party/PartyLogCard.tsx
@@ -1,0 +1,72 @@
+import { Party } from '@/types/party';
+import Tag from '../common/Tag';
+import { Skeleton } from '../ui/skeleton';
+import { Button } from '../ui/button';
+
+interface PartyCardProps {
+  data: Party;
+}
+
+export function PartyLogCardSkeleton() {
+  return (
+    <div className="flex flex-col gap-2 p-5 w-[410px] border-2 border-neutral-300 rounded-xl">
+      <Skeleton className="h-[160px] rounded-xl" />
+      <div className="flex gap-2">
+        <Skeleton className="h-6 rounded-sm w-1/6" />
+        <Skeleton className="h-6 rounded-sm w-1/6" />
+      </div>
+      <Skeleton className="h-8 rounded-sm w-1/2" />
+      <Skeleton className="h-6 rounded-sm" />
+      <div className="flex justify-between py-2">
+        <div className="flex gap-1">
+          <Skeleton className="h-5 w-5 rounded-full" />
+          <Skeleton className="h-5 w-5 rounded-full" />
+          <Skeleton className="h-5 w-5 rounded-full" />
+          <Skeleton className="h-5 w-5 rounded-full" />
+        </div>
+        <Skeleton className="h-5 w-10 rounded-sm" />
+      </div>
+    </div>
+  );
+}
+
+export default function PartyLogCard({ data }: PartyCardProps) {
+  return (
+    <div className="flex flex-col gap-4 p-5 w-[410px] rounded-xl bg-white border-[1px] border-neutral-300 cursor-pointer">
+      <div
+        style={{
+          backgroundImage: `url(${data.game_image})`,
+        }}
+        className="flex flex-col h-[160px] rounded-xl overflow-hidden justify-between group bg-cover bg-center"
+      ></div>
+      <div className="flex flex-col gap-1">
+        <div className="font-suit text-2xl font-semibold line-clamp-1 text-neutral-900">{data.name}</div>
+        <div className="flex justify-between items-center">
+          <Tag style="time" className="px-0">
+            {formatDate(data.party_at)}
+          </Tag>
+          <div className="font-suit text-sm text-neutral-500">전체 {data.members.length}명</div>
+        </div>
+        <div className="flex gap-2 py-2">
+          {data.party_tags.map((tag) => (
+            <Tag background="medium" key={tag}>
+              {tag}
+            </Tag>
+          ))}
+        </div>
+      </div>
+      <Button className="text-lg h-10">파티 로그 확인</Button>
+    </div>
+  );
+}
+
+// 날짜 포맷팅 함수
+function formatDate(targetDate: Date) {
+  return targetDate.toLocaleString('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}

--- a/src/components/party/PartyLogCard.tsx
+++ b/src/components/party/PartyLogCard.tsx
@@ -7,7 +7,7 @@ import formatDate from '@/utils/formatDate';
 
 interface PartyCardProps {
   data: Party;
-  onCardClick: () => void;
+  onBtnClick: () => void;
 }
 
 export function PartyLogCardSkeleton() {
@@ -30,7 +30,7 @@ export function PartyLogCardSkeleton() {
   );
 }
 
-export default function PartyLogCard({ data, onCardClick }: PartyCardProps) {
+export default function PartyLogCard({ data, onBtnClick: onCardClick }: PartyCardProps) {
   return (
     <div className="flex flex-col gap-4 p-5 w-[410px] rounded-xl bg-white border-[1px] border-neutral-300 cursor-pointer">
       <div

--- a/src/components/party/PartyLogCard.tsx
+++ b/src/components/party/PartyLogCard.tsx
@@ -12,23 +12,20 @@ interface PartyCardProps {
 
 export function PartyLogCardSkeleton() {
   return (
-    <div className="flex flex-col gap-2 p-5 w-[410px] border-2 border-neutral-300 rounded-xl">
+    <div className="flex flex-col gap-4 p-5 w-[410px] border-2 border-neutral-300 rounded-xl">
       <Skeleton className="h-[160px] rounded-xl" />
-      <div className="flex gap-2">
-        <Skeleton className="h-6 rounded-sm w-1/6" />
-        <Skeleton className="h-6 rounded-sm w-1/6" />
-      </div>
-      <Skeleton className="h-8 rounded-sm w-1/2" />
-      <Skeleton className="h-6 rounded-sm" />
-      <div className="flex justify-between py-2">
-        <div className="flex gap-1">
-          <Skeleton className="h-5 w-5 rounded-full" />
-          <Skeleton className="h-5 w-5 rounded-full" />
-          <Skeleton className="h-5 w-5 rounded-full" />
-          <Skeleton className="h-5 w-5 rounded-full" />
+      <div className="flex flex-col gap-1">
+        <Skeleton className="h-8 rounded-sm w-1/2" />
+        <div className="flex justify-between py-2">
+          <Skeleton className="h-5 w-1/4 rounded-sm" />
+          <Skeleton className="h-5 w-10 rounded-sm" />
         </div>
-        <Skeleton className="h-5 w-10 rounded-sm" />
+        <div className="flex gap-2">
+          <Skeleton className="h-6 rounded-sm w-1/6" />
+          <Skeleton className="h-6 rounded-sm w-1/6" />
+        </div>
       </div>
+      <Skeleton className="w-full h-10" />
     </div>
   );
 }

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,10 @@
+// 날짜 포맷팅 함수
+export default function formatDate(targetDate: Date) {
+  return targetDate.toLocaleString('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#27 

## 📝작업 내용

PartyLogCard, PartyLogCardSkeleton 컴포넌트 작업했습니다.

![스크린샷 2025-04-02 오전 9 47 49](https://github.com/user-attachments/assets/ce0c348e-2eb9-49c4-8208-04e91fb43c90)

사용방법은 아래와 같습니다.
```
  <PartyLogCard data={data} onBtnClick={() => alert('click')} />
  <PartyLogCardSkeleton />
```
- onBtnClick prop에서 라우팅 되는 함수를 전달하면, `파티 로그 확인` 버튼을 눌렀을 때 해당 상세 페이지로 이동하게 할 수 있을 것 같습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
