### PR TITLE
36 feat롤링 배너 스크롤 방향 지정

### DIFF
--- a/src/components/common/play-on-rolling-banner.tsx
+++ b/src/components/common/play-on-rolling-banner.tsx
@@ -3,9 +3,13 @@ import ControllerSVG from '@/components/svg/controller_fill';
 import PacmanSVG from '@/components/svg/pacman_fill';
 import GhostSVG from '@/components/svg/ghost_fill';
 
-export default function PlayOnRollingBanner(props: { speed: number }) {
+export default function PlayOnRollingBanner(props: { speed: number; direction: 'left' | 'right' }) {
   return (
-    <RollingBanner className="bg-gradient-to-r from-purple-700 to-purple-500 h-16" speed={props.speed}>
+    <RollingBanner
+      className="bg-gradient-to-r from-purple-700 to-purple-500 h-16"
+      speed={props.speed}
+      direction={props.direction}
+    >
       <div className="flex items-center gap-5 w-fit">
         <ControllerSVG width={32} fill="#FFFFFF" stroke="" />
         <p className="text-neutral-50 text-3xl font-black">PLAYON</p>

--- a/src/components/common/play-on-rolling-banner.tsx
+++ b/src/components/common/play-on-rolling-banner.tsx
@@ -3,13 +3,25 @@ import ControllerSVG from '@/components/svg/controller_fill';
 import PacmanSVG from '@/components/svg/pacman_fill';
 import GhostSVG from '@/components/svg/ghost_fill';
 
-export default function PlayOnRollingBanner(props: { speed: number; direction: 'left' | 'right' }) {
+export default function PlayOnRollingBanner(props: { duration: number; direction: 'left' | 'right' }) {
   return (
     <RollingBanner
       className="bg-gradient-to-r from-purple-700 to-purple-500 h-16 select-none"
-      speed={props.speed}
+      duration={props.duration}
       direction={props.direction}
     >
+      <div className="flex items-center gap-5 w-fit">
+        <ControllerSVG width={32} fill="#FFFFFF" stroke="" />
+        <p className="text-neutral-50 text-3xl font-black">PLAYON</p>
+      </div>
+      <div className="flex items-center gap-5 w-fit">
+        <PacmanSVG width={32} fill="#FFFFFF" stroke="" />
+        <p className="text-neutral-50 text-3xl font-black">PLAYON</p>
+      </div>
+      <div className="flex items-center gap-5 w-fit">
+        <GhostSVG width={32} fill="#FFFFFF" stroke="" />
+        <p className="text-neutral-50 text-3xl font-black">PLAYON</p>
+      </div>
       <div className="flex items-center gap-5 w-fit">
         <ControllerSVG width={32} fill="#FFFFFF" stroke="" />
         <p className="text-neutral-50 text-3xl font-black">PLAYON</p>

--- a/src/components/common/play-on-rolling-banner.tsx
+++ b/src/components/common/play-on-rolling-banner.tsx
@@ -6,7 +6,7 @@ import GhostSVG from '@/components/svg/ghost_fill';
 export default function PlayOnRollingBanner(props: { speed: number; direction: 'left' | 'right' }) {
   return (
     <RollingBanner
-      className="bg-gradient-to-r from-purple-700 to-purple-500 h-16"
+      className="bg-gradient-to-r from-purple-700 to-purple-500 h-16 select-none"
       speed={props.speed}
       direction={props.direction}
     >

--- a/src/components/common/rolling-banner/index.tsx
+++ b/src/components/common/rolling-banner/index.tsx
@@ -5,7 +5,7 @@ import './style.css';
 type RollingBannerProps = {
   className?: string;
   children: ReactNode[];
-  speed: number;
+  duration: number;
   direction: 'left' | 'right';
 };
 
@@ -19,7 +19,7 @@ export default function RollingBanner(props: RollingBannerProps) {
   return (
     <div className={`relative flex items-center overflow-hidden ${props.className}`}>
       <div
-        style={{ animationDuration: `${props.speed}s`, animationName: `${scrollDirection}` }}
+        style={{ animationDuration: `${props.duration}s`, animationName: `${scrollDirection}` }}
         className={`absolute rolling-list flex items-center gap-5`}
       >
         {props.children.map((e) => {

--- a/src/components/common/rolling-banner/index.tsx
+++ b/src/components/common/rolling-banner/index.tsx
@@ -6,6 +6,7 @@ type RollingBannerProps = {
   className?: string;
   children: ReactNode[];
   speed: number;
+  direction: 'left' | 'right';
 };
 
 export default function RollingBanner(props: RollingBannerProps) {
@@ -13,9 +14,14 @@ export default function RollingBanner(props: RollingBannerProps) {
     return <div className="rolling-item flex items-center justify-center">{child}</div>;
   }
 
+  const scrollDirection = props.direction === 'left' ? 'scrollLeft' : 'scrollRight';
+
   return (
     <div className={`relative flex items-center overflow-hidden ${props.className}`}>
-      <div style={{ animationDuration: `${props.speed}s` }} className={`absolute rolling-list flex items-center gap-5`}>
+      <div
+        style={{ animationDuration: `${props.speed}s`, animationName: `${scrollDirection}` }}
+        className={`absolute rolling-list flex items-center gap-5`}
+      >
         {props.children.map((e) => {
           return RollingBannerItem(e);
         })}

--- a/src/components/common/rolling-banner/index.tsx
+++ b/src/components/common/rolling-banner/index.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import './style.css';
 

--- a/src/components/common/rolling-banner/style.css
+++ b/src/components/common/rolling-banner/style.css
@@ -6,6 +6,14 @@
     transform: translateX(-100%);
   }
 }
+@keyframes scrollRight {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
 
 .rolling-list {
   box-sizing: border-box;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#36 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

롤링 배너의 스크롤 방햐을 지정할 수 있게 함
props로 direction='left' | 'right'

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
