### PR TITLE
Design: 레트로 버튼 CSS 일부 수정

### DIFF
--- a/src/components/common/RetroButton/style.css
+++ b/src/components/common/RetroButton/style.css
@@ -5,7 +5,7 @@
   background-color: #3f1ac4;
 }
 .retro-btn-shadow.purple {
-  background-color: #a3a3a3;
+  background-color: rgba(0, 0, 0, 0.4);
 }
 
 .retro-btn {
@@ -13,7 +13,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  border-radius: 25px;
+  border-radius: 9999px;
+  padding: 8px 20px;
   cursor: pointer;
   color: white;
   transition: all 0.1s ease-in-out;
@@ -37,7 +38,7 @@
   position: absolute;
   top: calc(0px + 9px);
   left: 0;
-  background-color: gray;
+  background-color: rgba(0, 0, 0, 0.4);
   width: calc(100%);
   height: calc(100%);
   border-radius: 25px;


### PR DESCRIPTION
## #️⃣연관된 이슈
#55 

## 📝작업 내용

Retro Button 컴포넌트 CSS 수정
버튼 얹어보니까 배경 있는 곳에서 컬러가 튀길래 rgba로 변경하고
아무 세팅 없을 때 기준으로 버튼 padding 좀 추가하겠습니다.

### 스크린샷 (선택)
**기존**
![Image](https://github.com/user-attachments/assets/557d317b-44ed-466f-8f4d-b74ee44eed56)
**수정**
![Image](https://github.com/user-attachments/assets/6fe1e510-3315-46ba-a75c-15b3b6755696)
