### PR TITLE
fix: replace username with nickname and resolve word break issue

### DIFF
--- a/src/app/party/components/AuthorInfo.tsx
+++ b/src/app/party/components/AuthorInfo.tsx
@@ -16,7 +16,7 @@ export default function AuthorInfo({ data }: AuthorInfoProps) {
       />
       <div className="flex flex-col w-full">
         <div className="text-base text-neutral-900">{data.user_title}</div>
-        <div className="text-xl text-neutral-900 font-bold break-words w-full" style={{ overflowWrap: 'anywhere' }}>
+        <div className="text-xl text-neutral-900 font-bold w-full" style={{ wordBreak: 'break-all' }}>
           {data.nickname}님의 파티
         </div>
       </div>

--- a/src/app/party/components/AuthorInfo.tsx
+++ b/src/app/party/components/AuthorInfo.tsx
@@ -16,7 +16,9 @@ export default function AuthorInfo({ data }: AuthorInfoProps) {
       />
       <div className="flex flex-col w-full">
         <div className="text-base text-neutral-900">{data.user_title}</div>
-        <div className="text-xl text-neutral-900 font-bold">{data.username}님의 파티</div>
+        <div className="text-xl text-neutral-900 font-bold break-words w-full" style={{ overflowWrap: 'anywhere' }}>
+          {data.nickname}님의 파티
+        </div>
       </div>
     </div>
   );

--- a/src/app/party/components/UserApprove.tsx
+++ b/src/app/party/components/UserApprove.tsx
@@ -22,7 +22,7 @@ export default function UserApprove({ data, onApprove, onReject }: UserApprovePr
         />
         <div className="flex flex-col">
           <div className="text-sm text-neutral-500 leading-5">{data.user_title}</div>
-          <div className="text-lg text-neutral-900 font-semibold">{data.username}</div>
+          <div className="text-lg text-neutral-900 font-semibold">{data.nickname}</div>
         </div>
       </div>
 

--- a/src/app/party/components/UserInfoHorizontal.tsx
+++ b/src/app/party/components/UserInfoHorizontal.tsx
@@ -43,7 +43,7 @@ export default function UserInfo({ size = 'big', data }: UserInfoProps) {
             'font-semibold': size === 'small',
           })}
         >
-          {data.username}
+          {data.nickname}
         </p>
       </div>
     </div>

--- a/src/app/party/components/UserInfoVertical.tsx
+++ b/src/app/party/components/UserInfoVertical.tsx
@@ -22,14 +22,14 @@ export default function UserInfoVertical({ isRadioBtn = false, data, name, onSel
   };
   return (
     <div className="inline-flex items-center flex-col gap-2">
-      <label htmlFor={data.username} className="relative">
+      <label htmlFor={data.nickname} className="relative">
         {isRadioBtn && (
           <input
             ref={radioRef}
             type="radio"
-            id={data.username}
+            id={data.nickname}
             name={name}
-            value={data.username}
+            value={data.nickname}
             onChange={handleChange}
             className="hidden peer"
           />
@@ -53,8 +53,10 @@ export default function UserInfoVertical({ isRadioBtn = false, data, name, onSel
         </div>
       </label>
 
-      <label htmlFor={data.username}>
-        <p className="font-suit text-neutral-900 font-bold text-base w-[100px] text-center">{data.username}</p>
+      <label htmlFor={data.nickname}>
+        <p className="font-suit text-neutral-900 font-bold text-base w-[100px] text-center break-words">
+          {data.nickname}
+        </p>
       </label>
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

#57 

## 📝작업 내용

1. username 사용중인 곳에 전부 nickname으로 수정했습니다.

2. 추가로 검토중에 global css에 word-break가 적용이 되면서 띄어쓰기가 되어 있지 않은 긴 글자는 다음 줄로 넘어가지 않는 문제가 있었습니다. 이를 해결하기 위해서 해당 컴포넌트 내에서 `break-words`나, `style={{ overflowWrap: 'anywhere' }}` 추가 해서 해결했는데, 괜찮은지 확인 부탁드립니다.

![스크린샷 2025-04-03 오후 9 46 00](https://github.com/user-attachments/assets/252a331a-68e1-4722-a16c-c1ffbdb6ddd4)


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
