### PR TITLE
feat: party main page publishing

### DIFF
--- a/src/app/party/page.tsx
+++ b/src/app/party/page.tsx
@@ -1,9 +1,61 @@
-import PartyCard from '@/components/party/PartyCard';
+'use client';
+import HeroTypingBanner from '@/components/common/HeroTypingBanner';
+import PlayOnRollingBanner from '@/components/common/play-on-rolling-banner';
+import RetroButton from '@/components/common/RetroButton';
+import SearchBar from '@/components/common/SearchBar';
+import PixelCharacter from '@/components/PixelCharacter/PixelCharacter';
+import { gameSimple } from '@/types/games';
+import { useState } from 'react';
+
+const popularGames: gameSimple[] = [
+  {
+    title: 'Counter Strike 2',
+    genre: ['몰라요'],
+    img_src: 'hero1.png',
+    background_src: 'hero1.png',
+  },
+  {
+    title: 'BATTLEGROUNDS',
+    genre: ['몰라요'],
+    img_src: './img/hero/bg_guild_2.webp',
+    background_src: 'hero1.png',
+  },
+];
 
 export default function Party() {
+  const [query, setQuery] = useState<string>('');
+  const handleChange = (value: string) => {
+    setQuery(value);
+    console.log(query);
+  };
+  const handleSearch = () => {
+    alert('search click!');
+  };
   return (
-    <div>
-      <p className="text-center text-5xl p-5">Party</p>
+    <div className="space-y-20">
+      <div className="w-full h-[400px]">
+        <HeroTypingBanner data={popularGames}>
+          <SearchBar onChange={handleChange} onSearch={handleSearch} className="w-[640px]" />
+        </HeroTypingBanner>
+      </div>
+      <section className="wrapper flex justify-between items-end">
+        <div>
+          <p className="text-neutral-900 text-2xl font-medium">구인중인 파티를 확인하고 빠르게 게임을 시작하세요.</p>
+          <div className="flex gap-6 items-center">
+            <p className="text-purple-700 text-6xl font-extrabold mt-2 mb-6">지금 모집중인 파티</p>
+            <div>아이콘자리</div>
+          </div>
+          <RetroButton type="purple" className="w-[344px] h-[48px]">
+            파티 상세 검색
+          </RetroButton>
+        </div>
+        <div className="flex">
+          {/* <PixelCharacter char="mage" motion="attack" />
+          <PixelCharacter char="archer" motion="attack" />
+          <PixelCharacter char="warrior" motion="attack" /> */}
+        </div>
+      </section>
+      <PlayOnRollingBanner duration={20} direction="left" />
     </div>
   );
 }

--- a/src/app/party/page.tsx
+++ b/src/app/party/page.tsx
@@ -5,6 +5,7 @@ import RetroButton from '@/components/common/RetroButton';
 import SearchBar from '@/components/common/SearchBar';
 import PixelCharacter from '@/components/PixelCharacter/PixelCharacter';
 import { gameSimple } from '@/types/games';
+import Image from 'next/image';
 import { useState } from 'react';
 
 const popularGames: gameSimple[] = [
@@ -41,18 +42,23 @@ export default function Party() {
       <section className="wrapper flex justify-between items-end">
         <div>
           <p className="text-neutral-900 text-2xl font-medium">구인중인 파티를 확인하고 빠르게 게임을 시작하세요.</p>
-          <div className="flex gap-6 items-center">
-            <p className="text-purple-700 text-6xl font-extrabold mt-2 mb-6">지금 모집중인 파티</p>
-            <div>아이콘자리</div>
+          <div className="flex gap-6 items-center mt-2 mb-6">
+            <p className="text-purple-700 text-6xl font-extrabold">지금 모집중인 파티</p>
+            <Image
+              src="./img/icons/pixel_swords.svg"
+              alt="swords icon"
+              height={40}
+              style={{ objectFit: 'contain' }}
+            ></Image>
           </div>
           <RetroButton type="purple" className="w-[344px] h-[48px]">
             파티 상세 검색
           </RetroButton>
         </div>
         <div className="flex">
-          {/* <PixelCharacter char="mage" motion="attack" />
+          <PixelCharacter char="mage" motion="attack" />
           <PixelCharacter char="archer" motion="attack" />
-          <PixelCharacter char="warrior" motion="attack" /> */}
+          <PixelCharacter char="warrior" motion="attack" />
         </div>
       </section>
       <PlayOnRollingBanner duration={20} direction="left" />

--- a/src/app/party/page.tsx
+++ b/src/app/party/page.tsx
@@ -3,9 +3,15 @@ import HeroTypingBanner from '@/components/common/HeroTypingBanner';
 import PlayOnRollingBanner from '@/components/common/play-on-rolling-banner';
 import RetroButton from '@/components/common/RetroButton';
 import SearchBar from '@/components/common/SearchBar';
+import SectionBanner from '@/components/common/SectionBanner';
+import SectionTitle from '@/components/common/SectionTitle';
+import PartyCard from '@/components/party/PartyCard';
+import PartyLogCard from '@/components/party/PartyLogCard';
 import PixelCharacter from '@/components/PixelCharacter/PixelCharacter';
 import { gameSimple } from '@/types/games';
-import Image from 'next/image';
+import { party, partyLog } from '@/types/party';
+import { dummyParty, dummyPartyLog } from '@/utils/dummyData';
+
 import { useState } from 'react';
 
 const popularGames: gameSimple[] = [
@@ -32,36 +38,77 @@ export default function Party() {
   const handleSearch = () => {
     alert('search click!');
   };
+
+  const dummyPartyList: party[] = Array(6).fill(dummyParty);
+  const dummyPartyLogList: partyLog[] = Array(3).fill(dummyPartyLog);
   return (
-    <div className="space-y-20">
-      <div className="w-full h-[400px]">
+    <div
+      style={{
+        backgroundImage: 'linear-gradient(to top, #f3e8ff 0%, rgba(255,255,255,0) 100%)',
+        backgroundSize: '100% 40%',
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'bottom',
+      }}
+      className="space-y-20 pb-20"
+    >
+      <section className="w-full h-[400px]">
         <HeroTypingBanner data={popularGames}>
           <SearchBar onChange={handleChange} onSearch={handleSearch} className="w-[640px]" />
         </HeroTypingBanner>
-      </div>
-      <section className="wrapper flex justify-between items-end">
-        <div>
-          <p className="text-neutral-900 text-2xl font-medium">구인중인 파티를 확인하고 빠르게 게임을 시작하세요.</p>
-          <div className="flex gap-6 items-center mt-2 mb-6">
-            <p className="text-purple-700 text-6xl font-extrabold">지금 모집중인 파티</p>
-            <Image
-              src="./img/icons/pixel_swords.svg"
-              alt="swords icon"
-              height={40}
-              style={{ objectFit: 'contain' }}
-            ></Image>
+      </section>
+
+      <section className="wrapper space-y-20">
+        <div className="flex justify-between items-end">
+          <SectionTitle
+            title="지금 모집중인 파티"
+            subtitle="구인중인 파티를 확인하고 빠르게 게임을 시작하세요"
+            icon_src="./img/icons/pixel_swords.svg"
+          >
+            <RetroButton type="purple" className="w-[344px] h-[48px]">
+              파티 상세 검색
+            </RetroButton>
+          </SectionTitle>
+          <div className="flex">
+            <PixelCharacter char="mage" motion="attack" />
+            <PixelCharacter char="archer" motion="attack" />
+            <PixelCharacter char="warrior" motion="attack" />
           </div>
-          <RetroButton type="purple" className="w-[344px] h-[48px]">
-            파티 상세 검색
-          </RetroButton>
         </div>
-        <div className="flex">
-          <PixelCharacter char="mage" motion="attack" />
-          <PixelCharacter char="archer" motion="attack" />
-          <PixelCharacter char="warrior" motion="attack" />
+        <div className="grid grid-cols-3 gap-6">
+          {dummyPartyList.map((party) => (
+            <PartyCard key={party.party_name} data={party} />
+          ))}
         </div>
       </section>
-      <PlayOnRollingBanner duration={20} direction="left" />
+
+      <section>
+        <PlayOnRollingBanner duration={20} direction="left" />
+      </section>
+
+      <section className="wrapper">
+        <SectionBanner
+          introText="딱 맞는 파티를 찾기 어려운가요?"
+          description="성향 및 목표가 같은 동료들과 함께하고 싶다면"
+          highlight="지금 바로 나만의 파티를 만들어보세요!"
+          onClick={() => alert('click')}
+        >
+          <img src="./img/3d_object/sword.webp" alt="icon" className="h-[180px] blur-[2px] -rotate-[30deg]" />
+          <img src="./img/3d_object/crystal_ball.webp" alt="icon" className="h-[180px]" />
+        </SectionBanner>
+      </section>
+
+      <section className="wrapper space-y-20">
+        <SectionTitle title="최신 파티 로그 살펴보기" subtitle="최근 플레이한 유저들의 플레이 기록을 보고 싶다면?">
+          <RetroButton type="purple" className="w-[344px] h-[48px]">
+            최신 파티 로그 살펴보기
+          </RetroButton>
+        </SectionTitle>
+        <div className="grid grid-cols-3 gap-6">
+          {dummyPartyLogList.map((partyLog) => (
+            <PartyLogCard key={partyLog.party_info.party_name} data={partyLog} />
+          ))}
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/components/common/HeroTypingBanner/index.tsx
+++ b/src/components/common/HeroTypingBanner/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { ReactNode, useCallback, useState } from 'react';
-import { gameSimple } from '@/types/games';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import type { Swiper as SwiperType } from 'swiper';
 import { EffectFade } from 'swiper/modules';
@@ -9,8 +8,13 @@ import './style.css';
 import 'swiper/css';
 import 'swiper/css/effect-fade';
 
+interface Banner {
+  title: string;
+  img_src: string;
+}
+
 interface HeroTypingBannerProps {
-  data: gameSimple[];
+  data: Banner[];
   isStatic?: boolean;
   children?: ReactNode;
 }

--- a/src/components/common/HeroTypingBanner/index.tsx
+++ b/src/components/common/HeroTypingBanner/index.tsx
@@ -1,20 +1,16 @@
 'use client';
 import { ReactNode, useCallback, useState } from 'react';
+import { gameSimple } from '@/types/games';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import { EffectFade } from 'swiper/modules';
 import type { Swiper as SwiperType } from 'swiper';
+import { EffectFade } from 'swiper/modules';
 import { Autoplay } from 'swiper/modules';
 import './style.css';
 import 'swiper/css';
 import 'swiper/css/effect-fade';
 
-type Banner = {
-  title: string;
-  image: string;
-};
-
 interface HeroTypingBannerProps {
-  data: Banner[];
+  data: gameSimple[];
   isStatic?: boolean;
   children?: ReactNode;
 }
@@ -34,7 +30,7 @@ export default function HeroTypingBanner({ data, isStatic, children }: HeroTypin
 
   if (isStatic) {
     return (
-      <div style={{ backgroundImage: `url(${data[0].image})` }} className="size-full bg-center bg-cover">
+      <div style={{ backgroundImage: `url(${data[0].img_src})` }} className="size-full bg-center bg-cover">
         <div className="size-full bg-purple-800/50 flex flex-col gap-5 items-center justify-center">
           <div className="flex align-middle gap-4 w-[560px]">
             <span className="text-white font-suit font-extrabold text-6xl leading-[80px]">PLAY ON</span>
@@ -67,7 +63,7 @@ export default function HeroTypingBanner({ data, isStatic, children }: HeroTypin
           <SwiperSlide key={idx} className="size-full">
             <div className="size-full bg-purple-800 relative">
               <div
-                style={{ backgroundImage: `url(${item.image})` }}
+                style={{ backgroundImage: `url(${item.img_src})` }}
                 className="size-full bg-top bg-cover blur-sm opacity-30 place-content-center place-items-center space-y-5"
               ></div>
             </div>
@@ -76,7 +72,7 @@ export default function HeroTypingBanner({ data, isStatic, children }: HeroTypin
       </Swiper>
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 place-content-center flex flex-col gap-8 items-center z-10">
         <div>
-          <p className="text-white font-suit text-xl min-w-[700px]">지금 핫한</p>
+          <p className="text-white font-suit text-xl min-w-[740px]">지금 핫한</p>
           <p
             key={index}
             className={`w-fit text-white font-suit font-extrabold text-8xl blur-none whitespace-nowrap typing-animation place-self-start ${isRemoving ? 'removing' : ''}`}

--- a/src/components/common/SectionBanner.tsx
+++ b/src/components/common/SectionBanner.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@/lib/utils';
+import { ReactNode } from 'react';
+
+interface SectionBannerProps {
+  introText?: string;
+  description: string;
+  highlight: string;
+  children: ReactNode[] | ReactNode; // icon 넣기
+  className?: string;
+  onClick?: () => void;
+}
+export default function SectionBanner({
+  introText,
+  description,
+  highlight,
+  children,
+  className,
+  onClick,
+}: SectionBannerProps) {
+  return (
+    <div
+      className={cn('w-full h-60 bg-purple-500 rounded-xl px-16 py-12 flex items-center justify-between', className)}
+      onClick={onClick}
+    >
+      <div className={`flex flex-col h-full ${introText ? 'justify-between' : 'justify-center'}`}>
+        {introText && <p className="text-2xl text-white font-light">{introText}</p>}
+        <div className="text-white">
+          <p className="text-4xl font-light leading-9">{description}</p>
+          <p className="text-[40px] font-bold">{highlight}</p>
+        </div>
+      </div>
+      <div className="flex gap-14">{children}</div>
+    </div>
+  );
+}

--- a/src/components/common/SectionTitle.tsx
+++ b/src/components/common/SectionTitle.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+interface SectionTitleProps {
+  title: string;
+  subtitle: string;
+  icon_src?: string;
+  children?: ReactNode;
+}
+
+export default function SectionTitle({ title, subtitle, icon_src, children }: SectionTitleProps) {
+  return (
+    <div>
+      <p className="text-neutral-900 text-2xl font-medium">{subtitle}</p>
+      <div className="flex gap-4 items-center mt-2 mb-6">
+        <p className="text-purple-700 text-6xl font-extrabold">{title}</p>
+        {icon_src && <img src={icon_src} alt="icon" className="h-14" />}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/party/PartyCard.tsx
+++ b/src/components/party/PartyCard.tsx
@@ -10,8 +10,8 @@ interface PartyCardProps {
 
 export function PartyCardSkeleton() {
   return (
-    <div className="flex flex-col gap-2 p-5 w-[410px] border-2 border-neutral-300 rounded-xl">
-      <Skeleton className="h-[160px] rounded-xl" />
+    <div className="flex flex-col gap-2 p-5 border-2 border-neutral-300 rounded-xl aspect-[113/100]">
+      <Skeleton className="aspect-[366/160] rounded-xl" />
       <div className="flex gap-2">
         <Skeleton className="h-6 rounded-sm w-1/6" />
         <Skeleton className="h-6 rounded-sm w-1/6" />
@@ -36,12 +36,12 @@ export default function PartyCard({ data }: PartyCardProps) {
   const remainingHours = getRemainingHours(data.start_time);
 
   return (
-    <div className="flex flex-col gap-2 p-5 w-[410px] rounded-xl bg-white border-2 border-neutral-300 cursor-pointer">
+    <div className="flex flex-col gap-2 p-5 rounded-xl bg-white border-2 border-neutral-300 cursor-pointer w-full aspect-[113/100]">
       <div
         style={{
           backgroundImage: `url(${data.selected_game.img_src})`,
         }}
-        className="flex flex-col h-[160px] rounded-xl overflow-hidden justify-between group bg-cover bg-center"
+        className="flex flex-col aspect-[366/160] rounded-xl overflow-hidden justify-between group bg-cover bg-center"
       >
         <div className="flex gap-2 ml-4 mt-4">
           {remainingHours >= 3 ? (

--- a/src/components/party/PartyLogCard.tsx
+++ b/src/components/party/PartyLogCard.tsx
@@ -13,8 +13,8 @@ interface PartyCardProps {
 
 export function PartyLogCardSkeleton() {
   return (
-    <div className="flex flex-col gap-4 p-5 w-[410px] border-[1px] border-neutral-300 rounded-xl">
-      <Skeleton className="h-[160px] rounded-xl" />
+    <div className="flex flex-col gap-4 p-5  w-full aspect-[113/100] border-[1px] border-neutral-300 rounded-xl">
+      <Skeleton className="aspect-[366/160] rounded-xl" />
       <div className="flex flex-col gap-1">
         <Skeleton className="h-8 rounded-sm w-1/2" />
         <div className="flex justify-between py-2">
@@ -37,12 +37,12 @@ export default function PartyLogCard({ data }: PartyCardProps) {
     router.push('/');
   };
   return (
-    <div className="flex flex-col gap-4 p-5 w-[410px] rounded-xl bg-white border-[1px] border-neutral-300 cursor-pointer">
+    <div className="flex flex-col gap-4 p-5 rounded-xl bg-white border-[1px] border-neutral-300 cursor-pointer w-full aspect-[113/100]">
       <div
         style={{
           backgroundImage: `url(${data.party_info.selected_game.img_src})`,
         }}
-        className="flex flex-col h-[160px] rounded-xl overflow-hidden justify-between group bg-cover bg-center"
+        className="flex flex-col aspect-[366/160] rounded-xl overflow-hidden justify-between group bg-cover bg-center"
       ></div>
       <div className="flex flex-col gap-1">
         <div className="font-suit text-2xl font-semibold truncate text-neutral-900">{data.party_info.party_name}</div>

--- a/src/utils/dummyData.ts
+++ b/src/utils/dummyData.ts
@@ -3,6 +3,7 @@ import { post } from '@/types/community';
 import { guild } from '@/types/guild';
 import { userDetail, userSimple } from '@/types/user';
 import { gameDetail, gameSimple } from '@/types/games';
+import { party, partyLog } from '@/types/party';
 
 export const dummyUserSimple: userSimple = {
   img_src: 'https://avatars.githubusercontent.com/u/124599?v=4',
@@ -79,4 +80,36 @@ export const dummyGuild: guild = {
   play_style: ['노멀', '도전과제'],
   skill_level: ['뉴비', '마스터'],
   main_game: dummyGameSimple,
+};
+
+export const dummyParty: party = {
+  party_name: '파티이름입니다.',
+  description: '설명입니다.설명입니다.설명입니다. 설명입니다. 설명입니다. 설명입니다. 설명입니다.',
+  start_time: new Date(),
+  tags: ['맛보기', '뉴비'],
+  participation: [dummyUserSimple],
+  selected_game: dummyGameSimple,
+  num_maximum: 10,
+};
+export const dummyPartyLog: partyLog = {
+  party_info: dummyParty,
+  player_recommend: [
+    {
+      to: dummyUserSimple,
+      from: dummyUserSimple,
+    },
+  ],
+  screenshot: [
+    {
+      img_src: 'https://shared.fastly.steamstatic.com/store_item_assets/steam/apps/489830/header.jpg?t=1721923149',
+      author: dummyUserSimple,
+      comment: '멋져요',
+    },
+  ],
+  review: [
+    {
+      author: dummyUserSimple,
+      text: '멋져요',
+    },
+  ],
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

#51

## 📝작업 내용

1. SectionTitle 컴포넌트 생성(src>components>common)
    :title, subtitle, icon_src 는 props로, 버튼은 children으로 넣어주면 됩니다
![스크린샷 2025-04-04 오후 12 04 57](https://github.com/user-attachments/assets/63a77efb-7063-4484-aaf7-54c8409e752d)

2. SectionBanner 컴포넌트 생성
    :introText, description, highlight는 props로, 3d 이미지는 children으로 넣어주면 됩니다.
![스크린샷 2025-04-04 오후 12 05 03](https://github.com/user-attachments/assets/e803a2af-e810-4082-9406-b6aeab3b829f)

3. dummyParty & dummyPartyLog 추가
    : utils > dummyData.ts 에 dummyParty & dummyPartyLog 추가했습니다.
4. 전체 페이지 퍼블리싱

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/bcac6a16-d774-4fc0-8106-48cbeeafa22f)

## 💬리뷰 요구사항(선택)
- PixelCharacter 컴포넌트 스타일은 이후에 수정하겠습니다.