### PR TITLE
Chore: helvetica compressed font setting edit

### DIFF
--- a/public/fonts/helvetica/helvetica.css
+++ b/public/fonts/helvetica/helvetica.css
@@ -1,4 +1,5 @@
 @font-face {
-  font-family: Helvetica, helvetica, sans-serif;
-  src: url(/fonts/helvetica/helvetica-compressed.otf);
+  font-family: HelveticaCompressed;
+  src: url(/fonts/helvetica/helvetica-compressed.otf) format('opentype');
+  font-weight: 400;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,7 +12,7 @@ const config: Config = {
       fontFamily: {
         suit: ['SUIT'],
         dgm: ['DungGeunMo'],
-        helvetica: ['Helvetica', 'helvetica'],
+        helvetica: ['HelveticaCompressed'],
       },
       colors: {
         purple: {


### PR DESCRIPTION
## #️⃣연관된 이슈
#81 

## 📝작업 내용
폰트 세팅 수정해놨습니다!
폰트 적용하면 자간이 좀 좁게 나오는데 tw에서 `tracking-wide`나 `tracking-wider` 클래스 사용하시면 됩니다.
