### PR TITLE
Feat: 파티 로그 페이지 퍼블리싱

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ["three"],
+  transpilePackages: ['three'],
+  images: {
+    domains: ['shared.fastly.steamstatic.com'],
+  },
 };
 
 export default nextConfig;

--- a/src/app/party/components/UserInfoVertical.tsx
+++ b/src/app/party/components/UserInfoVertical.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { userSimple } from '@/types/user';
 import { Trophy } from 'lucide-react';
 import { useRef } from 'react';

--- a/src/app/party/components/UserInfoVertical.tsx
+++ b/src/app/party/components/UserInfoVertical.tsx
@@ -46,7 +46,7 @@ export default function UserInfoVertical({ isRadioBtn = false, data, name, onSel
           style={{
             backgroundImage: `url(${data.img_src})`,
           }}
-          className="absolute top-0 rounded-full bg-center w-[100px] h-[100px] peer-checked:size-[92px] peer-checked:top-1 peer-checked:left-1 peer-checked:shadow-[inset_0px_0px_12px_3px_rgba(0,0,0,0.32)]"
+          className="absolute top-0 rounded-full bg-center bg-cover w-[100px] h-[100px] peer-checked:size-[92px] peer-checked:top-1 peer-checked:left-1 peer-checked:shadow-[inset_0px_0px_12px_3px_rgba(0,0,0,0.32)]"
         />
         <div className="opacity-0 peer-checked:opacity-20 absolute top-1 left-1 size-[92px] rounded-full bg-[#D18800]" />
 

--- a/src/app/party/log/components/DefaultInfo.tsx
+++ b/src/app/party/log/components/DefaultInfo.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import Tag from '@/components/common/Tag';
+import { partyLog } from '@/types/party';
+import formatDate from '@/utils/formatDate';
+import { timeCalc } from '@/utils/timeCalc';
+import UserInfoVertical from '../../components/UserInfoVertical';
+import React, { useRef, useState } from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+
+import 'swiper/css';
+import 'swiper/css/pagination';
+
+type Props = {
+  partyLog: partyLog;
+};
+
+export default function DefaultInfo({ partyLog }: Props) {
+  return (
+    <section className="flex flex-col gap-6">
+      <div className="text-center w-full flex flex-col justify-center">
+        <img src="/img/icons/pixel_swords.svg" alt="swords pixel icon" className="w-11 mx-auto" />
+        <p className="font-dgm text-purple-800 text-lg mb-4">Play complete!</p>
+        <h3 className="text-purple-700 text-5xl font-black">{partyLog.party_info.selected_game.title}</h3>
+      </div>
+      <div>
+        <h4 className="text-xl font-bold mb-1">파티 룸</h4>
+        <p className="text-3xl font-bold">{partyLog.party_info.party_name}</p>
+      </div>
+      <div>
+        <h4 className="text-xl font-bold mb-1">파티 스타일</h4>
+        <div className="flex gap-2">
+          {partyLog.party_info.tags.map((tag, idx) => (
+            <Tag key={idx} background="medium">
+              {tag}
+            </Tag>
+          ))}
+        </div>
+      </div>
+      <div>
+        <h4 className="text-xl font-bold mb-1">플레이 타임</h4>
+        <p>
+          {formatDate(partyLog.party_info.start_time, true)} |{' '}
+          {partyLog.party_info.end_time && timeCalc(partyLog.party_info.start_time, partyLog.party_info.end_time)}
+        </p>
+      </div>
+      <div>
+        <h4 className="text-xl font-bold mb-3">참여 인원</h4>
+        <Swiper
+          slidesPerView={1.5}
+          freeMode
+          scrollbar
+          breakpoints={{
+            480: {
+              slidesPerView: 2.5,
+            },
+            520: {
+              slidesPerView: 3.5,
+            },
+            720: {
+              slidesPerView: 5.5,
+            },
+            920: {
+              slidesPerView: 6.5,
+            },
+            1080: {
+              slidesPerView: 7.5,
+            },
+            1280: {
+              slidesPerView: 8.5,
+            },
+          }}
+        >
+          {partyLog.party_info.participation.map((user, idx) => (
+            <SwiperSlide>
+              <UserInfoVertical key={idx} data={user}></UserInfoVertical>
+            </SwiperSlide>
+          ))}
+          {partyLog.party_info.participation.map((user, idx) => (
+            <SwiperSlide>
+              <UserInfoVertical key={idx} data={user}></UserInfoVertical>
+            </SwiperSlide>
+          ))}
+          {partyLog.party_info.participation.map((user, idx) => (
+            <SwiperSlide>
+              <UserInfoVertical key={idx} data={user}></UserInfoVertical>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
+    </section>
+  );
+}

--- a/src/app/party/log/components/DefaultInfo.tsx
+++ b/src/app/party/log/components/DefaultInfo.tsx
@@ -21,11 +21,11 @@ export default function DefaultInfo({ partyLog }: Props) {
       <div className="text-center w-full flex flex-col justify-center">
         <img src="/img/icons/pixel_swords.svg" alt="swords pixel icon" className="w-11 mx-auto" />
         <p className="font-dgm text-purple-800 text-lg mb-4">Play complete!</p>
-        <h3 className="text-purple-700 text-5xl font-black">{partyLog.party_info.selected_game.title}</h3>
+        <h3 className="text-purple-700 text-7xl font-black">{partyLog.party_info.selected_game.title}</h3>
       </div>
       <div>
         <h4 className="text-xl font-bold mb-1">파티 룸</h4>
-        <p className="text-3xl font-bold">{partyLog.party_info.party_name}</p>
+        <p className="text-4xl font-bold">{partyLog.party_info.party_name}</p>
       </div>
       <div>
         <h4 className="text-xl font-bold mb-1">파티 스타일</h4>
@@ -72,17 +72,7 @@ export default function DefaultInfo({ partyLog }: Props) {
           }}
         >
           {partyLog.party_info.participation.map((user, idx) => (
-            <SwiperSlide>
-              <UserInfoVertical key={idx} data={user}></UserInfoVertical>
-            </SwiperSlide>
-          ))}
-          {partyLog.party_info.participation.map((user, idx) => (
-            <SwiperSlide>
-              <UserInfoVertical key={idx} data={user}></UserInfoVertical>
-            </SwiperSlide>
-          ))}
-          {partyLog.party_info.participation.map((user, idx) => (
-            <SwiperSlide>
+            <SwiperSlide key={idx}>
               <UserInfoVertical key={idx} data={user}></UserInfoVertical>
             </SwiperSlide>
           ))}

--- a/src/app/party/log/components/LogForm.tsx
+++ b/src/app/party/log/components/LogForm.tsx
@@ -1,0 +1,3 @@
+export default function LogForm() {
+  return <></>;
+}

--- a/src/app/party/log/components/LogForm.tsx
+++ b/src/app/party/log/components/LogForm.tsx
@@ -1,3 +1,0 @@
-export default function LogForm() {
-  return <></>;
-}

--- a/src/app/party/log/components/PlayerRecommendForm.tsx
+++ b/src/app/party/log/components/PlayerRecommendForm.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { Form, FormControl, FormField } from '@/components/ui/form';
+import { partyLog } from '@/types/party';
+import UserInfoVertical from '../../components/UserInfoVertical';
+
+const playerRecommendSchema = z.object({
+  recommend: z.string(),
+});
+
+type Props = {
+  partyLog: partyLog;
+};
+
+export default function PlayerRecommendForm({ partyLog }: Props) {
+  const form = useForm<z.infer<typeof playerRecommendSchema>>({
+    defaultValues: {
+      recommend: '',
+    },
+    resolver: zodResolver(playerRecommendSchema),
+  });
+  function onSubmit(data: z.infer<typeof playerRecommendSchema>) {
+    console.log('data : ', data);
+  }
+  return (
+    <div>
+      <h4 className="text-xl font-bold mb-3">플레이어 추천</h4>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <FormField
+            control={form.control}
+            name="recommend"
+            render={({ field }) => (
+              <FormControl>
+                <div className="flex gap-2">
+                  {partyLog.party_info.participation.map((member, idx) => (
+                    <div key={idx} className="cursor-pointer">
+                      <UserInfoVertical
+                        isRadioBtn
+                        name="recommend"
+                        data={member}
+                        onSelected={() => {
+                          field.onChange(member.username);
+                          form.handleSubmit(onSubmit)();
+                        }}
+                      ></UserInfoVertical>
+                    </div>
+                  ))}
+                </div>
+              </FormControl>
+            )}
+          />
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/app/party/log/components/PostInfo.tsx
+++ b/src/app/party/log/components/PostInfo.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { partyLog } from '@/types/party';
+import React, { useRef, useState } from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+
+import 'swiper/css';
+import 'swiper/css/pagination';
+import '../partySwiper.css';
+import { Pagination } from 'swiper/modules';
+import Image from 'next/image';
+import UserInfo from '../../components/UserInfoHorizontal';
+
+import styles from '../partyLog.module.css';
+
+type Props = {
+  partyLog: partyLog;
+};
+
+export default function PostInfo({ partyLog }: Props) {
+  return (
+    <section className="flex flex-col gap-12 mt-12">
+      <div>
+        <h4 className="text-xl font-bold mb-4">파티 스타일</h4>
+        <Swiper
+          className="screenshotSwiper"
+          scrollbar={{ hide: true }}
+          modules={[Pagination]}
+          pagination={{
+            type: 'progressbar',
+          }}
+          loop
+        >
+          {partyLog.screenshot.map((screenshot, idx) => (
+            <SwiperSlide>
+              <div className="flex gap-6 items-start">
+                <Image
+                  src={screenshot.img_src}
+                  alt={`${screenshot.author.nickname}의 스크린샷`}
+                  width={736}
+                  height={414}
+                  className="screen object-contain"
+                ></Image>
+                <div>
+                  <UserInfo data={screenshot.author} />
+                  <p
+                    className={`w-full bg-white p-4 max-w-screen-sm rounded-md border border-neutral-300 mt-4 ${styles.chatBubble}`}
+                  >
+                    {screenshot.comment}
+                  </p>
+                </div>
+              </div>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
+      <div>
+        <h4 className="text-xl font-bold mb-1">파티 후기</h4>
+        {partyLog.review.map((review, idx) => (
+          <div key={idx} className="py-4 border-b border-neutral-300 last:border-none">
+            <UserInfo data={review.author} size="small"></UserInfo>
+            <p>{review.text}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/party/log/components/PostInfo.tsx
+++ b/src/app/party/log/components/PostInfo.tsx
@@ -21,7 +21,7 @@ export default function PostInfo({ partyLog }: Props) {
   return (
     <section className="flex flex-col gap-12 mt-12">
       <div>
-        <h4 className="text-xl font-bold mb-4">파티 스타일</h4>
+        <h4 className="text-xl font-bold mb-4">스크린 샷</h4>
         <Swiper
           className="screenshotSwiper"
           scrollbar={{ hide: true }}

--- a/src/app/party/log/components/PostInfo.tsx
+++ b/src/app/party/log/components/PostInfo.tsx
@@ -32,7 +32,7 @@ export default function PostInfo({ partyLog }: Props) {
           loop
         >
           {partyLog.screenshot.map((screenshot, idx) => (
-            <SwiperSlide>
+            <SwiperSlide key={idx}>
               <div className="flex gap-6 items-start">
                 <Image
                   src={screenshot.img_src}

--- a/src/app/party/log/components/ReviewForm.tsx
+++ b/src/app/party/log/components/ReviewForm.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { Form, FormControl, FormField } from '@/components/ui/form';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+const reviewFormSchema = z.object({
+  review: z.string(),
+});
+
+export default function ReviewForm() {
+  //Default Form
+  const form = useForm<z.infer<typeof reviewFormSchema>>({
+    defaultValues: {
+      review: '',
+    },
+    resolver: zodResolver(reviewFormSchema),
+  });
+  function onSubmit(data: z.infer<typeof reviewFormSchema>) {
+    console.log('data : ', data);
+  }
+  return (
+    <div>
+      <h4 className="text-xl font-bold mb-2">파티 후기</h4>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <FormField
+            control={form.control}
+            name="review"
+            render={({ field }) => (
+              <FormControl>
+                <div className="flex flex-col items-end gap-3">
+                  <Textarea
+                    className="bg-white border-neutral-300 placeholder:text-neutral-400"
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder="파티 후기를 남겨주세요."
+                  />
+                  <Button className="py-5 px-8">추가하기</Button>
+                </div>
+              </FormControl>
+            )}
+          />
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/app/party/log/components/ScreenshotForm.tsx
+++ b/src/app/party/log/components/ScreenshotForm.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { Form, FormControl, FormField, FormItem } from '@/components/ui/form';
+import { ChangeEvent, useState } from 'react';
+import { EditIcon, ImageIcon } from 'lucide-react';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+const screenshotFormSchema = z.object({
+  screenshot_img: z
+    .any()
+    .optional()
+    .refine(
+      (file) => {
+        return !file || file instanceof File;
+      },
+      { message: '파일 형식이 잘못되었습니다.' }
+    ),
+  screenshot_comment: z.string(),
+});
+
+export default function ScreenshotForm() {
+  //Default Form
+  const form = useForm<z.infer<typeof screenshotFormSchema>>({
+    defaultValues: {
+      screenshot_img: '',
+      screenshot_comment: '',
+    },
+    resolver: zodResolver(screenshotFormSchema),
+  });
+
+  function onSubmit(data: z.infer<typeof screenshotFormSchema>) {
+    console.log('data : ', data);
+  }
+
+  //Image Controll
+  const [imageFile, setImageFile] = useState<string>('');
+  const NoImageInput = () => {
+    return (
+      <>
+        <label
+          htmlFor="screenshot_img"
+          className="border border-neutral-300 rounded w-1/2 h-48 cursor-pointer bg-neutral-300"
+        >
+          <div className="w-full h-full flex items-center justify-center">
+            <ImageIcon className="text-neutral-400" strokeWidth={1} width={40} height={40} />
+          </div>
+        </label>
+      </>
+    );
+  };
+  const ImageWithChange = () => {
+    return (
+      <div className="relative h-44 w-1/2 overflow-hidden rounded">
+        <img src={imageFile} alt="" />
+        <div className="absolute w-full h-full top-0 left-0 bg-black opacity-0 hover:opacity-25 transition-opacity rounded flex items-start justify-end p-2">
+          <label htmlFor="screenshot_img" className="cursor-pointer">
+            <EditIcon className="text-white" />
+          </label>
+        </div>
+      </div>
+    );
+  };
+  const onChangeImage = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      //validation here
+      const reader = new FileReader();
+      reader.readAsDataURL(e.target.files[0]);
+      reader.onloadend = () => {
+        setImageFile(reader.result ? reader.result.toString() : '');
+      };
+    }
+  };
+
+  return (
+    <div>
+      <h4 className="text-xl font-bold mb-2">스크린 샷</h4>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <div id="screenshot" className="flex gap-6">
+            {imageFile ? <ImageWithChange /> : <NoImageInput />}
+            <div className="w-1/2 flex flex-col gap-3 items-end">
+              <FormField
+                control={form.control}
+                name="screenshot_comment"
+                render={({ field }) => (
+                  <FormItem className="w-full">
+                    <FormControl>
+                      <Textarea
+                        className="bg-white border-neutral-300 placeholder:text-neutral-400"
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="스크린샷에 대한 코멘트를 남겨주세요."
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <Button className="py-5 px-8">추가하기</Button>
+            </div>
+            <input
+              className="hidden"
+              type="file"
+              name="screenshot_img"
+              id="screenshot_img"
+              accept="image/*"
+              onChange={onChangeImage}
+            />
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/app/party/log/page.tsx
+++ b/src/app/party/log/page.tsx
@@ -7,14 +7,17 @@ import PostInfo from './components/PostInfo';
 import UserInfoVertical from '../components/UserInfoVertical';
 import { Trophy } from 'lucide-react';
 import Image from 'next/image';
-import LogForm from './components/LogForm';
+import ReviewForm from './components/ReviewForm';
+import ScreenshotForm from './components/screenShotForm';
+import PlayerRecommendForm from './components/PlayerRecommendForm';
 
 export default function PartyLog() {
   const partyLog: partyLog = dummyPartyLog;
   const gameBackgroundUrl =
     'https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/page_bg_raw.jpg?t=1743743917';
   const mvp = dummyUserSimple;
-  const mpvRecommend = 5;
+  const mpvRecommend = 10;
+  const isParticipated = true; //이쪽에 토큰 받아서 참가자인지 확인
   return (
     <div className="bg-purple-100 pt-28 pb-32 ">
       <div
@@ -27,7 +30,7 @@ export default function PartyLog() {
         <div className="bg-white/40 backdrop-blur-md py-10 px-16 rounded-3xl relative border border-white">
           <DefaultInfo partyLog={partyLog} />
           <PostInfo partyLog={partyLog} />
-          <div className="absolute top-[220px] right-20 bg-white px-6 py-3 border-2 border-amber-400 rounded-xl ">
+          <div className="absolute top-[260px] right-20 bg-white px-6 py-3 border-2 border-amber-400 rounded-xl ">
             <UserInfoVertical data={mvp}></UserInfoVertical>
             <div className="flex text-amber-400 mt-2 justify-center flex-wrap">
               <Image
@@ -48,7 +51,16 @@ export default function PartyLog() {
             </div>
           </div>
         </div>
-        {false && <LogForm />}
+        {isParticipated && (
+          <div className="bg-white/40 backdrop-blur-md py-10 px-16 rounded-3xl relative border border-white mt-6">
+            <div className="flex flex-col gap-8">
+              <h4 className="text-center text-4xl font-extrabold text-purple-600">파티로그 작성</h4>
+              <ScreenshotForm />
+              <ReviewForm />
+              <PlayerRecommendForm partyLog={partyLog} />
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/app/party/log/page.tsx
+++ b/src/app/party/log/page.tsx
@@ -23,7 +23,7 @@ export default function PartyLog() {
         <div className="bg-gradient-to-b from-purple-50/0 to-purple-100 w-full h-1/2 absolute bottom-0"></div>
       </div>
       <div className="wrapper">
-        <div className="bg-white/30 backdrop-blur-md py-10 px-16 rounded-3xl relative">
+        <div className="bg-white/40 backdrop-blur-md py-10 px-16 rounded-3xl relative border border-white">
           <DefaultInfo partyLog={partyLog} />
           <PostInfo partyLog={partyLog} />
           <div className="absolute top-[220px] right-20 bg-white px-6 py-3 border-2 border-amber-400 rounded-xl ">
@@ -46,6 +46,9 @@ export default function PartyLog() {
               )}
             </div>
           </div>
+        </div>
+        <div className="bg-white/30 backdrop-blur-md py-10 px-16 rounded-3xl relative mt-8 border border-white">
+          <h4 className="text-3xl text-center font-bold">파티 로그 작성</h4>
         </div>
       </div>
     </div>

--- a/src/app/party/log/page.tsx
+++ b/src/app/party/log/page.tsx
@@ -7,6 +7,7 @@ import PostInfo from './components/PostInfo';
 import UserInfoVertical from '../components/UserInfoVertical';
 import { Trophy } from 'lucide-react';
 import Image from 'next/image';
+import LogForm from './components/LogForm';
 
 export default function PartyLog() {
   const partyLog: partyLog = dummyPartyLog;
@@ -47,9 +48,7 @@ export default function PartyLog() {
             </div>
           </div>
         </div>
-        <div className="bg-white/30 backdrop-blur-md py-10 px-16 rounded-3xl relative mt-8 border border-white">
-          <h4 className="text-3xl text-center font-bold">파티 로그 작성</h4>
-        </div>
+        {false && <LogForm />}
       </div>
     </div>
   );

--- a/src/app/party/log/page.tsx
+++ b/src/app/party/log/page.tsx
@@ -1,0 +1,29 @@
+import { partyLog } from '@/types/party';
+import { dummyPartyLog } from '@/utils/dummyData';
+import styles from './partyLog.module.css';
+
+import DefaultInfo from './components/DefaultInfo';
+import PostInfo from './components/PostInfo';
+
+export default function PartyLog() {
+  const partyLog: partyLog = dummyPartyLog;
+  const gameBackgroundUrl =
+    'https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/page_bg_raw.jpg?t=1743743917';
+
+  return (
+    <div className="bg-purple-100 pt-28">
+      <div
+        className={`${styles.background} w-full aspect-video absolute top-0`}
+        style={{ backgroundImage: `url(${gameBackgroundUrl})` }}
+      >
+        <div className="bg-gradient-to-b from-purple-50/0 to-purple-100 w-full h-1/2 absolute bottom-0"></div>
+      </div>
+      <div className="wrapper">
+        <div className="bg-white/30 backdrop-blur-md py-10 px-16 rounded-3xl">
+          <DefaultInfo partyLog={partyLog} />
+          <PostInfo partyLog={partyLog} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/party/log/page.tsx
+++ b/src/app/party/log/page.tsx
@@ -1,17 +1,21 @@
 import { partyLog } from '@/types/party';
-import { dummyPartyLog } from '@/utils/dummyData';
+import { dummyPartyLog, dummyUserSimple } from '@/utils/dummyData';
 import styles from './partyLog.module.css';
 
 import DefaultInfo from './components/DefaultInfo';
 import PostInfo from './components/PostInfo';
+import UserInfoVertical from '../components/UserInfoVertical';
+import { Trophy } from 'lucide-react';
+import Image from 'next/image';
 
 export default function PartyLog() {
   const partyLog: partyLog = dummyPartyLog;
   const gameBackgroundUrl =
     'https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/page_bg_raw.jpg?t=1743743917';
-
+  const mvp = dummyUserSimple;
+  const mpvRecommend = 5;
   return (
-    <div className="bg-purple-100 pt-28">
+    <div className="bg-purple-100 pt-28 pb-32 ">
       <div
         className={`${styles.background} w-full aspect-video absolute top-0`}
         style={{ backgroundImage: `url(${gameBackgroundUrl})` }}
@@ -19,9 +23,29 @@ export default function PartyLog() {
         <div className="bg-gradient-to-b from-purple-50/0 to-purple-100 w-full h-1/2 absolute bottom-0"></div>
       </div>
       <div className="wrapper">
-        <div className="bg-white/30 backdrop-blur-md py-10 px-16 rounded-3xl">
+        <div className="bg-white/30 backdrop-blur-md py-10 px-16 rounded-3xl relative">
           <DefaultInfo partyLog={partyLog} />
           <PostInfo partyLog={partyLog} />
+          <div className="absolute top-[220px] right-20 bg-white px-6 py-3 border-2 border-amber-400 rounded-xl ">
+            <UserInfoVertical data={mvp}></UserInfoVertical>
+            <div className="flex text-amber-400 mt-2 justify-center flex-wrap">
+              <Image
+                src="/img/laurel/laurel_mpv.png"
+                alt="mpv laurel"
+                width={160}
+                height={40}
+                className="absolute -top-1/3"
+              />
+              {Array.from({ length: Math.min(mpvRecommend, 3) }).map((_, idx) => (
+                <Trophy key={idx} />
+              ))}
+              {mpvRecommend > 3 && (
+                <div className="w-6 aspect-square bg-amber-400 rounded-full flex gap-1 items-center justify-center">
+                  <span className="text-xs font-bold text-white">+{mpvRecommend - 3}</span>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/party/log/partyLog.module.css
+++ b/src/app/party/log/partyLog.module.css
@@ -1,0 +1,29 @@
+.background {
+  background-position: 0% 0%;
+  background-repeat: no-repeat;
+  background-size: contain;
+  padding-top: 140px;
+}
+
+.chatBubble {
+  position: relative;
+}
+.chatBubble::before {
+  content: '';
+  position: absolute;
+  top: -12px;
+  left: 16px;
+  border-style: solid;
+  border-width: 12px 0 0 20px;
+  border-color: transparent transparent transparent rgb(212 212 212);
+}
+
+.chatBubble::after {
+  content: '';
+  position: absolute;
+  top: -12px;
+  left: 17px;
+  border-style: solid;
+  border-width: 13px 0 0 18px;
+  border-color: transparent transparent transparent white;
+}

--- a/src/app/party/log/partySwiper.css
+++ b/src/app/party/log/partySwiper.css
@@ -1,0 +1,20 @@
+.screenshotSwiper {
+  position: relative; /* 기준 */
+  padding-bottom: 20px; /* 아래 여백 확보 */
+}
+
+.screenshotSwiper.swiper-horizontal > .swiper-pagination-progressbar,
+.screenshotSwiper .swiper-pagination-progressbar.swiper-pagination-horizontal {
+  position: absolute;
+  top: auto;
+  bottom: 0px !important;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: #e5e5e5;
+  z-index: 10;
+}
+
+.screenshotSwiper .swiper-pagination-progressbar-fill {
+  background-color: #6738f6;
+}

--- a/src/types/party.ts
+++ b/src/types/party.ts
@@ -5,6 +5,7 @@ export interface party {
   party_name: string;
   description: string;
   start_time: Date;
+  end_time?: Date;
   tags: string[];
   participation: userSimple[];
   selected_game: gameSimple;

--- a/src/utils/dummyData.ts
+++ b/src/utils/dummyData.ts
@@ -1,4 +1,4 @@
-import { loremIpsum } from '@/utils/loremIpsum';
+import { loremIpsum } from './loremIpsum';
 import { post } from '@/types/community';
 import { guild, guildUser } from '@/types/guild';
 import { userDetail, userSimple } from '@/types/user';
@@ -134,11 +134,24 @@ export const dummyPartyLog: partyLog = {
       author: dummyUserSimple,
       comment: '멋져요',
     },
+    {
+      author: dummyUserSimple,
+      img_src: 'https://shared.fastly.steamstatic.com/store_item_assets/steam/apps/489830/header.jpg?t=1721923149',
+      comment: loremIpsum,
+    },
   ],
   review: [
     {
       author: dummyUserSimple,
       text: '멋져요',
+    },
+    {
+      author: dummyUserSimple,
+      text: loremIpsum,
+    },
+    {
+      author: dummyUserSimple,
+      text: loremIpsum,
     },
   ],
 };

--- a/src/utils/dummyData.ts
+++ b/src/utils/dummyData.ts
@@ -14,21 +14,21 @@ export const dummyUserSimple: userSimple = {
 export const dummyUsers: userSimple[] = [
   {
     img_src: 'https://avatars.githubusercontent.com/u/124599?v=4',
-    nickname: 'Morty',
+    nickname: '김영희',
     user_title: 'AdventureTime!',
-    username: 'morty1234@gmail.com',
+    username: 'yonghee@gmail.com',
   },
   {
     img_src: 'https://avatars.githubusercontent.com/u/124599?v=4',
-    nickname: 'Morty',
+    nickname: '홍길동',
     user_title: 'AdventureTime!',
-    username: 'morty1234@gmail.com',
+    username: 'gildong@gmail.com',
   },
   {
     img_src: 'https://avatars.githubusercontent.com/u/124599?v=4',
-    nickname: 'Abigale',
+    nickname: '태정태세비욘세',
     user_title: 'Stardew valley',
-    username: 'morty1234@gmail.com',
+    username: 'tetebi@email.com',
   },
 ];
 export const dummyUserDetail: userDetail = {

--- a/src/utils/dummyData.ts
+++ b/src/utils/dummyData.ts
@@ -11,6 +11,26 @@ export const dummyUserSimple: userSimple = {
   user_title: 'AdventureTime!',
   username: 'morty1234@gmail.com',
 };
+export const dummyUsers: userSimple[] = [
+  {
+    img_src: 'https://avatars.githubusercontent.com/u/124599?v=4',
+    nickname: 'Morty',
+    user_title: 'AdventureTime!',
+    username: 'morty1234@gmail.com',
+  },
+  {
+    img_src: 'https://avatars.githubusercontent.com/u/124599?v=4',
+    nickname: 'Morty',
+    user_title: 'AdventureTime!',
+    username: 'morty1234@gmail.com',
+  },
+  {
+    img_src: 'https://avatars.githubusercontent.com/u/124599?v=4',
+    nickname: 'Abigale',
+    user_title: 'Stardew valley',
+    username: 'morty1234@gmail.com',
+  },
+];
 export const dummyUserDetail: userDetail = {
   img_src: 'https://avatars.githubusercontent.com/u/124599?v=4',
   last_login_at: new Date(),
@@ -87,14 +107,15 @@ export const dummyGuildUser: guildUser = {
   guild_role: 'manager', // 'leader', 'manager', 'user'
   joined_at: new Date(),
   num_guild_posts: 17,
-}
+};
 
 export const dummyParty: party = {
   party_name: '파티이름입니다.',
   description: '설명입니다.설명입니다.설명입니다. 설명입니다. 설명입니다. 설명입니다. 설명입니다.',
   start_time: new Date(),
+  end_time: new Date(Date.now() + 8000000),
   tags: ['맛보기', '뉴비'],
-  participation: [dummyUserSimple],
+  participation: dummyUsers,
   selected_game: dummyGameSimple,
   num_maximum: 10,
 };

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,5 +1,15 @@
 // 날짜 포맷팅 함수
-export default function formatDate(targetDate: Date) {
+export default function formatDate(targetDate: Date, fullDate?: boolean) {
+  if (fullDate) {
+    return targetDate.toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+  }
   return targetDate.toLocaleString('ko-KR', {
     month: 'long',
     day: 'numeric',

--- a/src/utils/timeCalc.ts
+++ b/src/utils/timeCalc.ts
@@ -1,12 +1,15 @@
 export function timeCalc(startDate: Date, endDate: Date): string {
   let diff = Math.floor((endDate.getTime() - startDate.getTime()) / 1000);
+
   const days = Math.floor(diff / (3600 * 24));
+  diff %= 3600 * 24;
   const hours = Math.floor(diff / 3600);
+  diff %= 3600;
   const mins = Math.floor(diff / 60);
   const secs = diff % 60;
+  diff %= 60;
 
   const parts = [];
-
   if (days > 0) parts.push(`${days}D`);
   if (hours > 0) parts.push(`${hours}H`);
   if (mins > 0) parts.push(`${mins}M`);

--- a/src/utils/timeCalc.ts
+++ b/src/utils/timeCalc.ts
@@ -1,0 +1,16 @@
+export function timeCalc(startDate: Date, endDate: Date): string {
+  let diff = Math.floor((endDate.getTime() - startDate.getTime()) / 1000);
+  const days = Math.floor(diff / (3600 * 24));
+  const hours = Math.floor(diff / 3600);
+  const mins = Math.floor(diff / 60);
+  const secs = diff % 60;
+
+  const parts = [];
+
+  if (days > 0) parts.push(`${days}D`);
+  if (hours > 0) parts.push(`${hours}H`);
+  if (mins > 0) parts.push(`${mins}M`);
+  parts.push(`${secs}S`);
+
+  return parts.join(' ');
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#90 

## 📝작업 내용
파티 로그 페이지 퍼블리싱 작업

세부 사항
1. 시간 반환 함수
- 시작, 종료 시간에 맞춰 DHMS 형식으로 반환
- type 변경 있습니다. party 타입에 ```end_time?: Date;``` 추가 됐습니다.

2. 전반적인 구조
- App/party/log 페이지 안이 기본 페이지입니다.
- DetailInfo(기본 정보)
- PostInfo(추후 추가되는스크린샷, 파티 후기 세 가지)
- MPV (absolute 잡느냐 page.tsx에 들어있습니다...)
- 파티 로그 (스크린샷, 리뷰, mpv 추천 각각 개별 폼)

### 스크린샷 (선택)

전체 페이지
![image](https://github.com/user-attachments/assets/65d2daad-3c50-4e3d-ad04-f03d6eb3fb2a)

참가 인원 적을 때
![image](https://github.com/user-attachments/assets/df25423e-27d2-431a-9534-73227774357e)

참가 인원 많을 때 스와이퍼 처리
- breakpoints 적용해놨습니다.
![image](https://github.com/user-attachments/assets/c084f36b-faf0-465b-9d27-d874fe5e0098)

플레이어 추천
![image](https://github.com/user-attachments/assets/79727ed7-9d4c-4991-9432-8b9482e65846)

스크린샷 스와이퍼 
![image](https://github.com/user-attachments/assets/aadd45db-7fa8-442b-94fa-e22555f37ced)

mvp - 3명 이하
![image](https://github.com/user-attachments/assets/084cf337-778c-4e32-bdc5-93e280ec4532)

mvp - 3명이상 추천했을 시
![image](https://github.com/user-attachments/assets/a7538473-01b6-4c6e-ae24-c8bb4aabd412)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
