### PR TITLE
feat: 길드 커뮤니티 글작성 페이지 퍼블리싱

### DIFF
--- a/src/app/community/create/page.tsx
+++ b/src/app/community/create/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import RetroButton from '@/components/common/RetroButton';
+import InputImage from '@/components/community/input-image';
 import TextEditor from '@/components/community/TextEditor';
 import { Form, FormControl, FormField, FormItem } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
@@ -11,20 +12,61 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 const createCommunityFormSchema = z.object({
-  tag: z.string().default(''),
-  title: z.string().default(''),
-  content: z.string().default(''),
+  tag: z.string(),
+  title: z.string().min(1),
+  image: z.string(),
+  content: z.string().min(1),
 });
 type createCommunityFormType = z.infer<typeof createCommunityFormSchema>;
 
 export default function CommunityCreate() {
   const form = useForm<createCommunityFormType>({
+    defaultValues: {
+      tag: '',
+      title: '',
+      image: '',
+      content: '',
+    },
     resolver: zodResolver(createCommunityFormSchema),
   });
+
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
   function onSubmit(data: createCommunityFormType) {
     console.log('data : ', data);
   }
+
+  async function handleImageChange(e: React.ChangeEvent<HTMLInputElement>, onChange: (value: string) => void) {
+    const file = e.target.files?.[0];
+    if (!file) {
+      onChange('');
+      return;
+    }
+
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+
+    try {
+      const uploadedUrl = await uploadImageToS3(file);
+      onChange(uploadedUrl);
+    } catch (error) {
+      console.error('이미지 업로드 실패:', error);
+    }
+  }
+
+  // 모킹된 이미지 업로드 함수 (나주에 유틸 함수로 빼기)
+  const uploadImageToS3 = async (file: File): Promise<string> => {
+    return new Promise((resolve) => {
+      console.log('업로드할 파일:', file);
+
+      // 실제 S3 업로드 대신 딜레이 후 URL 반환
+      setTimeout(() => {
+        const mockUrl = `https://example-s3-bucket.amazonaws.com/${file.name}`;
+        console.log('업로드 성공! URL:', mockUrl);
+        resolve(mockUrl);
+      }, 1000); // 1초 딜레이 (업로드 시뮬레이션)
+    });
+  };
 
   return (
     <div className="wrapper mb-12 mt-28 space-y-10">
@@ -33,7 +75,7 @@ export default function CommunityCreate() {
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-10">
           <div className="space-y-7">
-            <div className="bg-neutral-50 rounded-2xl px-8 py-6 space-y-3">
+            <div className="bg-neutral-50 border border-neutral-300 rounded-2xl px-8 py-6 space-y-3">
               <FormField
                 control={form.control}
                 name="tag"
@@ -61,6 +103,8 @@ export default function CommunityCreate() {
                   <FormItem>
                     <FormControl>
                       <Input
+                        value={field.value}
+                        onChange={field.onChange}
                         placeholder="제목을 입력해주세요"
                         className="!text-xl w-full h-12 bg-white px-4 placeholder:text-neutral-400"
                       />
@@ -70,6 +114,17 @@ export default function CommunityCreate() {
               />
             </div>
           </div>
+          <FormField
+            control={form.control}
+            name="image"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <InputImage onChange={(e) => handleImageChange(e, field.onChange)} previewUrl={previewUrl} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
           <FormField
             control={form.control}
             name="content"

--- a/src/app/guild/community/create/page.tsx
+++ b/src/app/guild/community/create/page.tsx
@@ -1,0 +1,157 @@
+'use client';
+import RetroButton from '@/components/common/RetroButton';
+import InputImage from '@/components/community/input-image';
+import TextEditor from '@/components/community/TextEditor';
+import { Form, FormControl, FormField, FormItem } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { guild } from '@/types/guild';
+import { communityTags } from '@/types/Tags/communityTags';
+import { dummyGuild } from '@/utils/dummyData';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const createCommunityFormSchema = z.object({
+  tag: z.string(),
+  title: z.string().min(1),
+  image: z.string(),
+  content: z.string().min(1),
+});
+type createCommunityFormType = z.infer<typeof createCommunityFormSchema>;
+
+export default function CommunityCreate() {
+  const guild: guild = dummyGuild;
+
+  const form = useForm<createCommunityFormType>({
+    defaultValues: {
+      tag: '',
+      title: '',
+      image: '',
+      content: '',
+    },
+    resolver: zodResolver(createCommunityFormSchema),
+  });
+
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  function onSubmit(data: createCommunityFormType) {
+    console.log('data : ', data);
+  }
+
+  async function handleImageChange(e: React.ChangeEvent<HTMLInputElement>, onChange: (value: string) => void) {
+    const file = e.target.files?.[0];
+    if (!file) {
+      onChange('');
+      return;
+    }
+
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+
+    try {
+      const uploadedUrl = await uploadImageToS3(file);
+      onChange(uploadedUrl);
+    } catch (error) {
+      console.error('이미지 업로드 실패:', error);
+    }
+  }
+
+  // 모킹된 이미지 업로드 함수 (나주에 유틸 함수로 빼기)
+  const uploadImageToS3 = async (file: File): Promise<string> => {
+    return new Promise((resolve) => {
+      console.log('업로드할 파일:', file);
+
+      // 실제 S3 업로드 대신 딜레이 후 URL 반환
+      setTimeout(() => {
+        const mockUrl = `https://example-s3-bucket.amazonaws.com/${file.name}`;
+        console.log('업로드 성공! URL:', mockUrl);
+        resolve(mockUrl);
+      }, 1000); // 1초 딜레이 (업로드 시뮬레이션)
+    });
+  };
+
+  return (
+    <div className="wrapper mb-12 mt-28 space-y-10">
+      <div
+        style={{ backgroundImage: `url(${guild.img_src})` }}
+        className=" w-full h-[160px] rounded-2xl mt-12 bg-cover bg-center"
+      />
+      <div className="text-4xl text-neutral-900 font-bold"> 게시글 작성</div>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-10">
+          <div className="space-y-7">
+            <div className="bg-neutral-50 border border-neutral-300 rounded-2xl px-8 py-6 space-y-3">
+              <FormField
+                control={form.control}
+                name="tag"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger className="w-52 h-12 text-xl px-4 bg-white">
+                      <SelectValue placeholder="태그" className="placeholder:!text-neutral-400" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        {communityTags.map((tag) => (
+                          <SelectItem key={tag} value={tag} className="text-xl text-neutral-900">
+                            {tag}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="title"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <Input
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="제목을 입력해주세요"
+                        className="!text-xl w-full h-12 bg-white px-4 placeholder:text-neutral-400"
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </div>
+          </div>
+          <FormField
+            control={form.control}
+            name="image"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <InputImage onChange={(e) => handleImageChange(e, field.onChange)} previewUrl={previewUrl} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="content"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <TextEditor value={field.value} onChange={field.onChange} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          <button type="submit" className="self-end">
+            <RetroButton type="purple" className="w-64">
+              등록
+            </RetroButton>
+          </button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/components/community/TextEditor/index.tsx
+++ b/src/components/community/TextEditor/index.tsx
@@ -34,7 +34,7 @@ export default function TextEditor({ value, onChange, className }: TextEditorPro
         ['bold', 'italic', 'underline', 'strike', 'blockquote'],
         [{ color: [] }, { background: [] }],
         [{ align: [] }],
-        ['link', 'image'],
+        ['link'],
       ],
     }),
     []

--- a/src/components/community/input-image.tsx
+++ b/src/components/community/input-image.tsx
@@ -1,0 +1,25 @@
+import { Image } from 'lucide-react';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+
+interface InputImageProps {
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  previewUrl: string | null;
+}
+
+export default function InputImage({ onChange, previewUrl }: InputImageProps) {
+  return (
+    <>
+      <Label>
+        <Input type="file" id="image" onChange={onChange} className="hidden" />
+        <div className="flex w-full h-[180px] rounded-xl border border-neutral-300 bg-white cursor-pointer justify-center items-center overflow-hidden">
+          {previewUrl ? (
+            <img src={previewUrl} alt="미리보기" className="object-cover w-full h-full" />
+          ) : (
+            <Image strokeWidth={1.6} className="text-neutral-300 size-10" />
+          )}
+        </div>
+      </Label>
+    </>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#111 

## 📝작업 내용

1. 길드 커뮤니티 글작성 페이지 ui 작업 했습니다.
2. 길드 커뮤니티와, 자유게시판 쪽 모두에 이미지 업로드 할 수 있는 input 추가해두었습니다.

레이아웃을 이대로 둬도 될지 고민이 됩니다..
- 길드 커뮤니티 (이미지 업로드 전)
![screencapture-localhost-3000-guild-community-create-2025-04-07-16_09_42](https://github.com/user-attachments/assets/be92a1e7-eeb9-4f06-84f5-1beadff80819)
- 자유게시판 (이미지 업로드 후)
![screencapture-localhost-3000-community-create-2025-04-07-16_32_26](https://github.com/user-attachments/assets/367b311b-853a-414e-ab2b-f2aba552cfe4)



### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
