### PR TITLE
Feat: 파티 상세 페이지 퍼블리싱

### DIFF
--- a/src/app/party/components/UserApprove.tsx
+++ b/src/app/party/components/UserApprove.tsx
@@ -30,7 +30,11 @@ export default function UserApprove({ data, onApprove, onReject }: UserApprovePr
         <Button onClick={() => onApprove()} className="bg-neutral-900 text-sm px-4">
           승인
         </Button>
-        <Button onClick={() => onReject()} variant={'outline'} className="border-neutral-900 text-neutral-900 text-sm">
+        <Button
+          onClick={() => onReject()}
+          variant={'outline'}
+          className="border-neutral-900 text-neutral-900 text-sm bg-transparent"
+        >
           거부
         </Button>
       </div>

--- a/src/app/party/detail/components/InfoAccordion.tsx
+++ b/src/app/party/detail/components/InfoAccordion.tsx
@@ -36,7 +36,7 @@ export default function InfoAccordion({ participated, setParticipated }: Props) 
       )}
       {open && (
         <div className="flex py-8 gap-8 align-tops">
-          <div className="w-80">
+          <div className="w-[460px]">
             <PartyHostInfo partyHost={partyHost} />
             <div className="flex flex-col gap-3 pt-8">
               {isAuthor && (

--- a/src/app/party/detail/components/InfoAccordion.tsx
+++ b/src/app/party/detail/components/InfoAccordion.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { ChevronUp, Send, SquarePen, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import UserInfoHorizontal from '../../components/UserInfoHorizontal';
+import { dummyUserSimple } from '@/utils/dummyData';
+import { dummyParty } from '@/utils/dummyData';
+import UserApprove from '../../components/UserApprove';
+import { userSimple } from '@/types/user';
+import RetroButton from '@/components/common/RetroButton';
+import Tag from '@/components/common/Tag';
+import formatDate from '@/utils/formatDate';
+import { Avatar } from '@/components/ui/avatar';
+import Link from 'next/link';
+
+type Props = {
+  participated: boolean;
+  setParticipated: React.Dispatch<React.SetStateAction<boolean>>;
+};
+export default function InfoAccordion({ participated, setParticipated }: Props) {
+  const [open, setOpen] = useState(true);
+  const isAuthor = true;
+  function getButtonLabel(participating: boolean) {
+    if (participating) return '참가 취소하기';
+    setParticipated(false);
+    return '파티 참가하기';
+  }
+  const partyHost = { ...dummyParty.participation[0] };
+  return (
+    <section>
+      {participated && (
+        <button className="flex gap-6 items-center w-full pb-5" onClick={() => setOpen(!open)}>
+          <ChevronUp className={`${open && 'rotate-180'} transition-all ease-in-out`} />
+          <h4 className="text-2xl font-extrabold">파티 정보</h4>
+        </button>
+      )}
+      {open && (
+        <div className="flex py-8 gap-8 align-tops">
+          <div className="w-80">
+            <PartyHostInfo partyHost={partyHost} />
+            <div className="flex flex-col gap-3 pt-8">
+              {isAuthor && (
+                <>
+                  <p className="font-bold text-xl">파티 신청 대기 중</p>
+                  <UserApprove data={dummyUserSimple} onApprove={() => {}} onReject={() => {}} />
+                  <UserApprove data={dummyUserSimple} onApprove={() => {}} onReject={() => {}} />
+                </>
+              )}
+              {!isAuthor && (
+                <RetroButton
+                  type="purple"
+                  callback={() => {
+                    setParticipated(!participated);
+                  }}
+                >
+                  {getButtonLabel(participated)}
+                </RetroButton>
+              )}
+            </div>
+          </div>
+          <ul id="partInfo" className="flex flex-col gap-7 w-full relative">
+            {isAuthor && (
+              <div className="flex items-center gap-2 justify-end absolute -top-8 right-0 text-sm">
+                <button className="flex items-center">
+                  <Send className="h-3" /> 초대장 보내기
+                </button>
+                <button className="flex items-center">
+                  <SquarePen className="h-3" /> 파티 수정
+                </button>
+                <button className="flex items-center">
+                  <Trash2 className="h-3" /> 파티 삭제
+                </button>
+              </div>
+            )}
+            <li>
+              <h3 className="text-4xl font-bold mb-3">{dummyParty.party_name}</h3>
+              <div className="flex gap-2">
+                {dummyParty.tags.map((tag) => (
+                  <Tag style="retro" background="dark">
+                    {tag}
+                  </Tag>
+                ))}
+              </div>
+            </li>
+            <li>
+              <h5 className="text-xl font-extrabold">시작 시간</h5>
+              <p>{formatDate(dummyParty.start_time)} 출발</p>
+            </li>
+            <li>
+              <h5 className="text-xl font-extrabold">참가 인원</h5>
+              <div className="flex py-2 justify-between">
+                <div className="flex gap-3 items-center">
+                  {dummyParty.participation.map((member, idx) =>
+                    idx < 8 ? (
+                      <Link href={`user/${member.username}`} target="_blank">
+                        <Avatar
+                          key={idx}
+                          style={{
+                            backgroundImage: `url(${member.img_src})`,
+                          }}
+                          className="bg-cover bg-center w-12 h-12"
+                        />
+                      </Link>
+                    ) : null
+                  )}
+                  {dummyParty.participation.length - 8 >= 1 && (
+                    <div className="font-suit text-lg font-semibold ml-2 text-neutral-600">
+                      +{dummyParty.participation.length - 4}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </li>
+            <li>
+              <p>{dummyParty.description}</p>
+            </li>
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PartyHostInfo({ partyHost }: { partyHost: userSimple }) {
+  return (
+    <div className="flex gap-3 border-b border-white/20 pb-8">
+      <div
+        id="createdUser"
+        className={`bg-center bg-cover w-20 h-20 rounded-full`}
+        style={{ backgroundImage: `url(${partyHost.img_src})` }}
+      ></div>
+      <div>
+        <span className="text-sm text-neutral-600">{partyHost.user_title}</span>
+        <p className="text-2xl font-extrabold">{partyHost.nickname}님의 파티</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/party/detail/components/InfoChatting.tsx
+++ b/src/app/party/detail/components/InfoChatting.tsx
@@ -1,0 +1,70 @@
+'use client';
+import RetroButton from '@/components/common/RetroButton';
+import Chat from '@/components/guildUser/Chat';
+import { Avatar } from '@/components/ui/avatar';
+import { dummyParty } from '@/utils/dummyData';
+import { loremIpsum } from '@/utils/loremIpsum';
+import { useState } from 'react';
+export default function InfoChatting() {
+  const [chatting, setChatting] = useState(false);
+  function getButtonLabel(participating: boolean) {
+    if (participating) return '채팅 퇴장하기';
+    return '채팅 참여하기';
+  }
+  return (
+    <div className="border-t border-white/20 pt-8">
+      <div id="participatedInfomation" className="flex justify-between items-center">
+        <div>
+          <h5 className="text-xl font-extrabold">채팅 참가 중</h5>
+          <div className="flex py-2 justify-between">
+            <div className="flex gap-2 items-center">
+              {dummyParty.participation.map((member, idx) =>
+                idx < 8 ? (
+                  <Avatar
+                    key={idx}
+                    style={{
+                      backgroundImage: `url(${member.img_src})`,
+                    }}
+                    className="bg-cover bg-center w-10 h-10"
+                  />
+                ) : null
+              )}
+              {dummyParty.participation.length - 8 >= 1 && (
+                <div className="font-suit text-lg font-semibold ml-2 text-neutral-600">
+                  +{dummyParty.participation.length - 4}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+        <RetroButton
+          type="purple"
+          callback={() => {
+            setChatting(!chatting);
+          }}
+        >
+          {getButtonLabel(chatting)}
+        </RetroButton>
+      </div>
+      {chatting && (
+        <div
+          id="chattingRoom"
+          className="bg-neutral-500/20 p-12 rounded-xl max-h-[680px] overflow-y-scroll mt-6 gap-y-3 flex flex-col"
+        >
+          {dummyParty.participation.map((member) => (
+            <Chat data={member} message={member.user_title} isSender={member.nickname == '홍길동'} />
+          ))}
+          {dummyParty.participation.map((member) => (
+            <Chat data={member} message={loremIpsum} isSender={member.nickname == '홍길동'} />
+          ))}
+          {dummyParty.participation.map((member) => (
+            <Chat data={member} message={member.user_title} isSender={member.nickname == '홍길동'} />
+          ))}
+          {dummyParty.participation.map((member) => (
+            <Chat data={member} message={member.user_title} isSender={member.nickname == '홍길동'} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/party/detail/page.tsx
+++ b/src/app/party/detail/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { partyLog } from '@/types/party';
+import { dummyPartyLog } from '@/utils/dummyData';
+import styles from './partyDetail.module.css';
+import { Accordion, AccordionTrigger, AccordionContent, AccordionItem } from '@/components/ui/accordion';
+import InfoAccordion from './components/InfoAccordion';
+import { useState } from 'react';
+import InfoChatting from './components/InfoChatting';
+const gameBackgroundUrl =
+  'https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/2246340/page_bg_raw.jpg?t=1743743917';
+
+export default function PartyDetail() {
+  const partyLog: partyLog = dummyPartyLog;
+  const [participated, setParticipated] = useState(true);
+  return (
+    <div className="bg-purple-100 pt-28 pb-16 min-h-screen flex items-center">
+      <div
+        className={`${styles.background} w-full aspect-video absolute top-0 z-0`}
+        style={{ backgroundImage: `url(${gameBackgroundUrl})` }}
+      >
+        <div className="bg-gradient-to-b from-purple-50/0 to-purple-100 w-full h-1/2 absolute bottom-0"></div>
+      </div>
+      <div className="wrapper relative z-10 w-full">
+        <div className="bg-white/50 backdrop-blur-md py-10 px-16 rounded-3xl relative border border-whit">
+          <InfoAccordion participated={participated} setParticipated={setParticipated} />
+          {participated && <InfoChatting />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/party/detail/partyDetail.module.css
+++ b/src/app/party/detail/partyDetail.module.css
@@ -1,0 +1,6 @@
+.background {
+  background-position: 0% 0%;
+  background-repeat: no-repeat;
+  background-size: contain;
+  padding-top: 140px;
+}

--- a/src/components/guildUser/Chat.tsx
+++ b/src/components/guildUser/Chat.tsx
@@ -1,8 +1,9 @@
+import { userSimple } from '@/types/user';
 import { Avatar, AvatarImage } from '../ui/avatar';
 import { guildUser } from '@/types/guild';
 
 interface chatCradProps {
-  data: guildUser;
+  data: userSimple;
   isSender?: boolean;
   message: string;
 }
@@ -12,16 +13,18 @@ export default function Chat(props: chatCradProps) {
 
   return (
     <>
-      <div className={`flex ${isSender ? 'justify-start flex-row' : 'flex-row-reverse'} gap-5 items-center`}>
-        <Avatar className="bg-neutral-400 w-16 h-16">
-          <AvatarImage src={data.user.img_src} />
-        </Avatar>
+      <div className={`flex ${!isSender ? 'justify-start flex-row' : 'flex-row-reverse'} gap-2 items-center`}>
+        {!isSender && (
+          <Avatar className="bg-neutral-400 w-16 h-16">
+            <AvatarImage src={data.img_src} />
+          </Avatar>
+        )}
         <div className={`box-content bg-neutral-200 rounded-lg px-5 py-2 ${isSender ? 'mr-3' : 'ml-3'}`}>
           <div className="flex gap-1">
-            {isSender && (
+            {!isSender && (
               <div>
-                <p className="font-suit text-xs text-neutral-400 font-normal">{data.user.user_title}</p>
-                <p className="font-suit text-xs text-purple-600 font-bold">{data.user.nickname}</p>
+                <p className="font-suit text-xs text-neutral-400 font-normal">{data.user_title}</p>
+                <p className="font-suit text-xs text-purple-600 font-bold">{data.nickname}</p>
               </div>
             )}
           </div>


### PR DESCRIPTION
## #️⃣연관된 이슈
#109 

## 📝작업 내용

1. 채팅 컴포넌트 변경 @aiden-328 
- 채팅 컴포넌트 타유저와 본인 방향이 역방향이라 수정했습니다.
- 본인이 보낸 채팅메세지 프로필 삭제했습니다
- 타입이 guildUser로 되어있어서 변경했습니다.

2. 유저 승인 컴포넌트 변경 @kylekim95
- 배경색 지웠습니다.

3. 파티 상세 페이지 퍼블리싱
호스트 여부 / 파티 참가여부/ 채팅 참가 여부에 따라 조건부 렌더링
`app/party/detail` 이 기본 페이지이며
참가 전 볼 수 있는 파티 정보는 `InfoAccordion` 컴포넌트
참가 후 볼 수 있는 채팅 정보는 `InfoChatting` 컴포넌트입니다.

### 스크린샷 (선택)

파티 호스트일 때
![image](https://github.com/user-attachments/assets/3c7c6505-2bff-4c83-9ee7-6b08b23544f5)

파티에 참가 중이지 않을 때
![image](https://github.com/user-attachments/assets/63940ecb-5089-4eee-8c76-5002efc9e4fa)

파티에 참가 중일 때
![image](https://github.com/user-attachments/assets/da57aa21-68c5-4366-b6d3-51f501917f98)

채팅에 참가 중일 때
![image](https://github.com/user-attachments/assets/f75c75a2-5f7b-4029-a524-42544e73d230)

추가로 인원은 8명 이상이면 +N 처리 해놨습니다.
![image](https://github.com/user-attachments/assets/5904e91c-7da2-49a6-aa1d-f96f5eeb49fa)
