### PR TITLE
design: 게임 메인 페이지 디자인 수정

### DIFF
--- a/src/app/game/game.module.css
+++ b/src/app/game/game.module.css
@@ -1,0 +1,17 @@
+.chatBubble {
+  position: relative;
+}
+.chatBubble::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border: 14px solid transparent;
+  border-top-color: #ffffff;
+  border-top-width: 16px;
+  border-bottom: 0;
+  margin-left: -14px;
+  margin-bottom: -14px;
+}

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -3,14 +3,12 @@
 import HeroSwiperBanner from '@/components/common/HeroSwiperBanner';
 import PlayOnRollingBanner from '@/components/common/play-on-rolling-banner';
 import SearchBar from '@/components/common/SearchBar';
+import SectionTitle from '@/components/common/SectionTitle';
 import PickCard from '@/components/game/PickCard';
 import PopularCard from '@/components/game/PopularCard';
 import SteamCard from '@/components/game/SteamCard';
 import { dummyGameSimple, dummyUserSimple } from '@/utils/dummyData';
-
-// import Chat from "@/components/guildUser/Chat";
-// import GuildUser from "@/components/guildUser/GuildUser";
-// import GuildUserCard from "@/components/guildUser/GuildUserCard";
+import styles from './game.module.css';
 
 export default function Game() {
   const imageList = [
@@ -20,50 +18,44 @@ export default function Game() {
   ];
 
   return (
-    <main>
+    <main className="mb-20 space-y-20">
       <section>
-        <div className="w-screen relative">
-          <section className="w-full h-[520px] pt-[68px]">
-            <HeroSwiperBanner data={imageList}></HeroSwiperBanner>
-          </section>
-          {/* <img src="/img/hero/bg_game_2.webp" className="w-full h-[520px] object-cover" /> */}
-          <div className="w-[1280px] absolute left-1/2 -translate-x-1/2 top-[196px]">
-            <div className="top-[196px] place-self-center">
-              <SearchBar className="w-[640px]" placeholder="게임 이름으로 검색하세요" />
+        <div className="bg-purple-400/20 w-full h-[800px]">
+          <div className="w-screen relative">
+            <div className="w-full h-[520px] mt-[68px] relative">
+              <HeroSwiperBanner data={imageList} />
             </div>
-
-            <div className="pt-20">
-              <div className="box-content w-[340px] h-20 bg-white rounded-xl place-self-center">
-                <div className="py-2">
+            <div className="w-[1280px] absolute left-1/2 -translate-x-1/2 top-48 z-10 space-y-7">
+              <SearchBar
+                className="w-[640px] place-self-center mb-20"
+                placeholder="게임 이름으로 검색하세요"
+                onChange={() => console.log('change')}
+                onSearch={() => alert('click')}
+              />
+              <div className={`box-content w-[340px] bg-white rounded-xl place-self-center ${styles.chatBubble}`}>
+                <div className="py-3 space-y-2 ">
                   <p className="font-suit text-base font-medium leading-5 text-center">플레이온 유저들의 선택</p>
                   <p className="font-suit text-4xl font-black text-purple-700 text-center">BEST CHOICE</p>
                 </div>
               </div>
-              <img src="/img/icons/Polygon 2.svg" className="place-self-center" />
-            </div>
 
-            <div className="grid grid-cols-3 md:grid-cols-3 gap-6 pt-4">
-              <PopularCard data={dummyGameSimple} />
-              <PopularCard data={dummyGameSimple} />
-              <PopularCard data={dummyGameSimple} />
+              <div className="grid grid-cols-3 md:grid-cols-3 gap-6 pt-4">
+                <PopularCard data={dummyGameSimple} />
+                <PopularCard data={dummyGameSimple} />
+                <PopularCard data={dummyGameSimple} />
+              </div>
             </div>
           </div>
         </div>
+        <PlayOnRollingBanner duration={20} direction="left" />
       </section>
 
-      <div className="mt-72">
-        <PlayOnRollingBanner duration={20} direction="left" />
-      </div>
-
       <section className="wrapper">
-        <div className="pt-24">
-          <p className="font-suit text-2xl font-medium">최근 함께 파티에 참여한 유저들이 플레이했어요</p>
-          <div className="flex gap-5  pt-1">
-            <p className="font-suit text-6xl font-extrabold text-purple-700">파티원 PICK</p>
-            <img src="/img/icons/pixel_chat_heart.svg" alt="" />
-          </div>
-        </div>
-
+        <SectionTitle
+          title="파티원 PICK"
+          subtitle="최근 함께 파티에 참여한 유저들이 플레이했어요"
+          icon_src="/img/icons/pixel_chat_heart.svg"
+        />
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6 pt-8">
           <PickCard data={dummyGameSimple} />
           <PickCard data={dummyGameSimple} />
@@ -72,32 +64,31 @@ export default function Game() {
         </div>
       </section>
 
-      <section>
-        <div className="w-screen relative pt-20">
-          <img src="/hero1.png" className="w-full h-[692px] blur-[30px] object-cover bg-[#23243DCC]" />
+      <section className="w-full">
+        <div className="bg-[url('/img/hero/bg_gameList_5.webp')] bg-cover bg-center size-full">
+          <div className="bg-purple-800/60 size-full backdrop-blur-md">
+            <div className="wrapper py-12 space-y-8">
+              <p className="text-5xl font-suit font-bold text-white">STEAM RANKING</p>
 
-          <div className="wrapper">
-            <div className="w-[1280px] absolute left-1/2 -translate-x-1/2 top-32">
-              <p className="text-5xl font-suit font-extrabold text-white">STEAM RANKING</p>
-
-              <div className="flex flex-row pt-7 gap-7">
-                <div className="w-[845px] h-[394px]">
-                  <div className="relative">
+              <div className="flex gap-6">
+                <div className="w-[845px] h-[394px] space-y-8">
+                  <div className="relative pt-3">
                     <img src={dummyGameSimple.img_src} className="w-full rounded-xl bg-neutral-400 object-cover" />
-                    <div className="absolute top-0 left-0 pt-3 pl-3 w-32">
+                    <div className="absolute top-0 left-0 pt-6 pl-3 w-32">
                       <img src="/img/laurel/laurel_1st.png" />
                     </div>
                   </div>
-
-                  <p className="mt-4 font-suit text-5xl font-extrabold text-white"> {dummyGameSimple.title}</p>
-                  <p className="mt-2 text-lg text-white font-medium"> {dummyGameSimple.genre.join(', ')}</p>
+                  <div className="space-y-4">
+                    <p className="font-suit text-5xl font-bold text-white"> {dummyGameSimple.title}</p>
+                    <p className="text-lg text-white font-medium"> {dummyGameSimple.genre.join(', ')}</p>
+                  </div>
                 </div>
 
                 <div className="grid grid-cols-2 gap-6 w-[411px]">
-                  <SteamCard data={dummyGameSimple} className="text-white" />
-                  <SteamCard data={dummyGameSimple} className="text-white" />
-                  <SteamCard data={dummyGameSimple} className="text-white" />
-                  <SteamCard data={dummyGameSimple} className="text-white" />
+                  <SteamCard data={dummyGameSimple} className="text-white" theme="dark" />
+                  <SteamCard data={dummyGameSimple} className="text-white" theme="dark" />
+                  <SteamCard data={dummyGameSimple} className="text-white" theme="dark" />
+                  <SteamCard data={dummyGameSimple} className="text-white" theme="dark" />
                 </div>
               </div>
             </div>
@@ -105,34 +96,32 @@ export default function Game() {
         </div>
       </section>
 
-      <section className="wrapper">
-        <div className="pt-28">
-          <p className="font-suit text-2xl font-medium">내가 좋아하는 장르 위주로</p>
-          <div className="flex gap-5  pt-1">
-            <p className="font-suit text-6xl font-extrabold text-purple-700">{dummyUserSimple.nickname}님 맞춤 추천</p>
-            <img src="/img/icons/pixel_present.svg" alt="" />
+      <section className="wrapper space-y-20">
+        <div className="space-y-8">
+          <SectionTitle
+            title={`${dummyUserSimple.nickname}님 맞춤 추천`}
+            subtitle="내가 좋아하는 장르 위주로"
+            icon_src="/img/icons/pixel_present.svg"
+          />
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+            <PickCard data={dummyGameSimple} />
+            <PickCard data={dummyGameSimple} />
+            <PickCard data={dummyGameSimple} />
+            <PickCard data={dummyGameSimple} />
           </div>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 pt-16">
-          <PickCard data={dummyGameSimple} />
-          <PickCard data={dummyGameSimple} />
-          <PickCard data={dummyGameSimple} />
-          <PickCard data={dummyGameSimple} />
-        </div>
-
-        <div className="pt-32">
-          <p className="font-suit text-2xl font-medium">오래해도 떨어지지 않는 재미</p>
-          <div className="flex gap-5 pt-1">
-            <p className="font-suit text-6xl font-extrabold text-purple-700">플레이타임 긴 게임들</p>
-            <img src="/img/icons/pixel_box.svg" alt="" />
+        <div className="space-y-8">
+          <SectionTitle
+            title="플레이타임 긴 게임들"
+            subtitle="오래해도 떨어지지 않는 재미"
+            icon_src="/img/icons/pixel_box.svg"
+          />
+          <div className="grid grid-cols-3 md:grid-cols-3 gap-6">
+            <PopularCard data={dummyGameSimple} />
+            <PopularCard data={dummyGameSimple} />
+            <PopularCard data={dummyGameSimple} />
           </div>
-        </div>
-
-        <div className="grid grid-cols-3 md:grid-cols-3 gap-6 pt-6">
-          <PopularCard data={dummyGameSimple} />
-          <PopularCard data={dummyGameSimple} />
-          <PopularCard data={dummyGameSimple} />
         </div>
       </section>
     </main>


### PR DESCRIPTION


## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

게임 메인 페이지 수정했습니다.
- 말풍선 css 구현
- 상단 배너쪽 배경색 추가
- steam ranking 섹션 배경 수정
- sectionTitle 컴포넌트 적용

![screencapture-localhost-3001-game-2025-04-07-22_08_39](https://github.com/user-attachments/assets/a45e94a4-9b09-4105-8c97-107cb3cd671e)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
