### PR TITLE
design: 글작성 페이지 이미지 삽입 섹션 UI 수정

### DIFF
--- a/src/app/community/create/page.tsx
+++ b/src/app/community/create/page.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { communityTags } from '@/types/Tags/communityTags';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { ChevronDown } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -114,17 +115,24 @@ export default function CommunityCreate() {
               />
             </div>
           </div>
-          <FormField
-            control={form.control}
-            name="image"
-            render={({ field }) => (
-              <FormItem>
-                <FormControl>
-                  <InputImage onChange={(e) => handleImageChange(e, field.onChange)} previewUrl={previewUrl} />
-                </FormControl>
-              </FormItem>
-            )}
-          />
+          <div className="bg-neutral-50 border border-neutral-300 rounded-2xl px-8 py-6 group overflow-hidden">
+            <label className="flex gap-7 items-center ">
+              <input type="checkbox" className="hidden peer" />
+              <p className="text-2xl text-neutral-900 font-semibold">이미지 첨부하기</p>
+              <ChevronDown className="text-neutral-700 peer-checked:rotate-180 transition-transform" />
+            </label>
+            <FormField
+              control={form.control}
+              name="image"
+              render={({ field }) => (
+                <FormItem className="pt-6 group-has-[input:checked]:opacity-0 group-has-[input:checked]:h-0 group-has-[input:checked]:pt-0 transition-all">
+                  <FormControl>
+                    <InputImage onChange={(e) => handleImageChange(e, field.onChange)} previewUrl={previewUrl} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </div>
           <FormField
             control={form.control}
             name="content"

--- a/src/app/guild/community/create/page.tsx
+++ b/src/app/guild/community/create/page.tsx
@@ -9,6 +9,7 @@ import { guild } from '@/types/guild';
 import { communityTags } from '@/types/Tags/communityTags';
 import { dummyGuild } from '@/utils/dummyData';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { ChevronDown } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -121,17 +122,24 @@ export default function CommunityCreate() {
               />
             </div>
           </div>
-          <FormField
-            control={form.control}
-            name="image"
-            render={({ field }) => (
-              <FormItem>
-                <FormControl>
-                  <InputImage onChange={(e) => handleImageChange(e, field.onChange)} previewUrl={previewUrl} />
-                </FormControl>
-              </FormItem>
-            )}
-          />
+          <div className="bg-neutral-50 border border-neutral-300 rounded-2xl px-8 py-6 group overflow-hidden">
+            <label className="flex gap-7 items-center ">
+              <input type="checkbox" className="hidden peer" />
+              <p className="text-2xl text-neutral-900 font-semibold">이미지 첨부하기</p>
+              <ChevronDown className="text-neutral-700 peer-checked:rotate-180 transition-transform" />
+            </label>
+            <FormField
+              control={form.control}
+              name="image"
+              render={({ field }) => (
+                <FormItem className="pt-6 group-has-[input:checked]:opacity-0 group-has-[input:checked]:h-0 group-has-[input:checked]:pt-0 transition-all">
+                  <FormControl>
+                    <InputImage onChange={(e) => handleImageChange(e, field.onChange)} previewUrl={previewUrl} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </div>
 
           <FormField
             control={form.control}

--- a/src/components/community/input-image.tsx
+++ b/src/components/community/input-image.tsx
@@ -10,16 +10,24 @@ interface InputImageProps {
 export default function InputImage({ onChange, previewUrl }: InputImageProps) {
   return (
     <>
-      <Label>
-        <Input type="file" id="image" onChange={onChange} className="hidden" />
-        <div className="flex w-full h-[180px] rounded-xl border border-neutral-300 bg-white cursor-pointer justify-center items-center overflow-hidden">
+      <div className="flex gap-4">
+        <Label
+          htmlFor="image"
+          className="flex aspect-[16/9] min-w-[400px] max-w-[400px] rounded-xl border border-neutral-200 bg-white cursor-pointer justify-center items-center overflow-hidden"
+        >
           {previewUrl ? (
             <img src={previewUrl} alt="미리보기" className="object-cover w-full h-full" />
           ) : (
-            <Image strokeWidth={1.6} className="text-neutral-300 size-10" />
+            <Image strokeWidth={1.6} className="text-neutral-300 size-10 place-self-center" />
           )}
-        </div>
-      </Label>
+        </Label>
+        <Input
+          type="file"
+          id="image"
+          onChange={onChange}
+          className="text-neutral-500 font-normal file:text-neutral-700 w-[400px] bg-white"
+        />
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#127 

## 📝작업 내용

기능은 동일하고, 아래의 사진과 같이 ui 수정했습니다.

### 스크린샷 (선택)
- 길드 커뮤니티 글 작성 페이지 (이미지 없음)
![screencapture-localhost-3000-guild-community-create-2025-04-08-15_03_46](https://github.com/user-attachments/assets/49485c21-7139-412f-b662-218932ba372e)

- 길드 커뮤니티 글 작성 페이지 (이미지 섹션 접었을 때)
![screencapture-localhost-3000-guild-community-create-2025-04-08-15_06_48](https://github.com/user-attachments/assets/fe1c7d61-14bb-46ca-a876-5f9f7bca270f)

- 자유게시판 글 작성 페이지 (이미지 있음)
![screencapture-localhost-3000-community-create-2025-04-08-15_03_24](https://github.com/user-attachments/assets/0e78abb5-6e19-4609-8cdd-8a4d3a136929)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
