### PR TITLE
feat: endpoints 정의

### DIFF
--- a/src/constants/endpoints/batch-job.ts
+++ b/src/constants/endpoints/batch-job.ts
@@ -1,0 +1,3 @@
+export const BATCH_JOB_ENDPOINTS = Object.freeze({
+  batch: '/batch/steam-game',
+});

--- a/src/constants/endpoints/game.ts
+++ b/src/constants/endpoints/game.ts
@@ -1,0 +1,11 @@
+export const GAME_ENDPOINTS = Object.freeze({
+  game: (gameId: string) => `/games/${gameId}`,
+  party: (gameId: string) => `/games/${gameId}/party`,
+  logs: (gameId: string) => `/games/${gameId}/logs`,
+  details: (gameId: string) => `/games/${gameId}/details`,
+  search: '/games/search',
+  recommend: '/games/recommend',
+  ranking: '/games/ranking',
+  popular: '/games/popular',
+  list: '/games/list',
+});

--- a/src/constants/endpoints/guild-join.ts
+++ b/src/constants/endpoints/guild-join.ts
@@ -1,0 +1,6 @@
+export const GUILD_JOIN_ENDPOINTS = Object.freeze({
+  join: (guildId: string) => `/guilds/${guildId}/join`,
+  reject: (guildId: string, requestId: string) => `/guilds/${guildId}/join/${requestId}/reject`,
+  approve: (guildId: string, requestId: string) => `/guilds/${guildId}/join/${requestId}/approve`,
+  requests: (guildId: string) => `/guilds/${guildId}/join/requests`,
+});

--- a/src/constants/endpoints/guild-member.ts
+++ b/src/constants/endpoints/guild-member.ts
@@ -1,0 +1,8 @@
+export const GUILD_MEMBER_ENDPOINTS = Object.freeze({
+  select_manager: (guildId: string) => `/guilds/${guildId}/managers`,
+  delete_manager: (guildId: string) => `/guilds/${guildId}/managers`,
+  invite: (guildId: string) => `/guilds/${guildId}/invite`,
+  list: (guildId: string) => `/guilds/${guildId}/members`,
+  delete_member: (guildId: string) => `/guilds/${guildId}/members`,
+  leave: (guildId: string) => `/guilds/${guildId}/members/leave`,
+});

--- a/src/constants/endpoints/guild.ts
+++ b/src/constants/endpoints/guild.ts
@@ -1,0 +1,9 @@
+export const GUILD_ENDPOINTS = Object.freeze({
+  detail: (guildId: string) => `/guilds/${guildId}`,
+  modify: (guildId: string) => `/guilds/${guildId}`,
+  delete: (guildId: string) => `/guilds/${guildId}`,
+  list: '/guilds',
+  create: '/guilds',
+  recommend: '/guilds/recommend',
+  popular: '/guilds/popular',
+});

--- a/src/constants/endpoints/member.ts
+++ b/src/constants/endpoints/member.ts
@@ -1,0 +1,9 @@
+export const MEMBER_ENDPOINTS = Object.freeze({
+  me: '/members/me',
+  modify: '/members/me',
+  delete: '/members/me',
+  signup: '/members/signup',
+  login: '/members/login',
+  nickname: '/members/nickname',
+  games: '/members/me/games',
+});

--- a/src/constants/endpoints/notification.ts
+++ b/src/constants/endpoints/notification.ts
@@ -1,0 +1,7 @@
+export const NOTIFICATION_ENDPOINTS = Object.freeze({
+  send: '/notifications/send',
+  read: (notificationId: string) => `/notifications/${notificationId}/read`,
+  list: '/notifications',
+  summary: '/notifications/summary',
+  subscribe: '/notifications/subscribe',
+});

--- a/src/constants/endpoints/party-log.ts
+++ b/src/constants/endpoints/party-log.ts
@@ -1,0 +1,7 @@
+export const PARTYLOG_ENDPOINTS = Object.freeze({
+  modify: (logId: string, partyId: string) => `/logs/${logId}/party/${partyId}`,
+  delete: (logId: string, partyId: string) => `/logs/${logId}/party/${partyId}`,
+  screenshot: (logId: string, partyId: string) => `/logs/${logId}/party/${partyId}/screenshot`,
+  list: (partyId: string) => `/logs/party/${partyId}`,
+  write: (partyId: string) => `/logs/party/${partyId}`,
+});

--- a/src/constants/endpoints/party.ts
+++ b/src/constants/endpoints/party.ts
@@ -1,0 +1,15 @@
+export const PARTY_ENDPOINTS = Object.freeze({
+  detail: (partyId: string) => `/parties/${partyId}`,
+  modify: (partyId: string) => `/parties/${partyId}`,
+  cancel: (partyId: string) => `/parties/${partyId}`,
+  accept_member: (partyId: string, memberId: string) => `/parties/${partyId}/members/${memberId}`,
+  reject_member: (partyId: string, memberId: string) => `/parties/${partyId}/members/${memberId}`,
+  list: '/parties',
+  create: '/parties',
+  join: (partyId: string) => `/parties/${partyId}/members`,
+  invite: (partyId: string, memberId: string) => `/parties/${partyId}/members/${memberId}/invitation`,
+  result: (partyId: string) => `/parties/${partyId}/result`,
+  pending: (partyId: string) => `/parties/${partyId}/pending`,
+  main_pending: '/parties/main/pending',
+  main_completed: '/parties/main/completed',
+});

--- a/src/constants/endpoints/steam-auth.ts
+++ b/src/constants/endpoints/steam-auth.ts
@@ -1,0 +1,9 @@
+export const STEAM_AUTH_ENDPOINTS = Object.freeze({
+  logout: '/auth/steam/logout',
+  signup: '/auth/steam/signup',
+  login: '/auth/steam/login',
+  link: '/auth/steam/link',
+  callback_signup: '/auth/steam/callback/signup',
+  callback_login: '/auth/steam/callback/login',
+  callback_link: '/auth/steam/callback/link',
+});

--- a/src/constants/endpoints/title.ts
+++ b/src/constants/endpoints/title.ts
@@ -1,0 +1,6 @@
+export const TITLE_ENDPOINTS = Object.freeze({
+  my_title: (titleId: string) => `/titles/${titleId}`,
+  all_title: '/titles',
+});
+// 내가 가지고 있는 칭호 리스트 조회 없음
+// all_title이 해당 기능을 하는 것이라면 memberId 필요없나?


### PR DESCRIPTION
## #️⃣연관된 이슈

#145 

## 📝작업 내용

현재 swagger 기준 api endpoint 정의 했습니다.

아래는 작업 중에 생긴 의문 사항입니다.
- title endpoint에 `/api/titles (사용자의 모든 칭호 조회)` 가 있는데, 사용자의 모든 칭호를 조회하기 위해서는 memberId가 필요없는게 맞는지 확인해보아야 할 것 같습니다.
- guild-member endpoint 에 `/api/guilds/{guildId}/members/leave` 사용시, 방장이 탈퇴할 경우에는 권한을 위임한 후 탈퇴가 가능합니다. 그런데 클라이언트에서 방장 탈퇴시 방장 권한을 위임할 수 있는 기능이 없는 것 같습니다.

![image](https://github.com/user-attachments/assets/d4188190-e823-4114-8c8c-e5b9f673039e)


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
