### PR TITLE
fix: HeroSwiperBanner 버그 해결

### DIFF
--- a/src/components/common/HeroSwiperBanner.tsx
+++ b/src/components/common/HeroSwiperBanner.tsx
@@ -35,7 +35,7 @@ export default function HeroSwiperBanner({ data, children }: HeroSwiperBannerPro
           <SwiperSlide key={item.title}>
             <div style={{ backgroundImage: `url(${item.img_src})` }} className="size-full bg-center bg-cover">
               <div className="size-full bg-purple-600/15">
-                <div className="flex wrapper pt-5 justify-end">
+                <div className="flex wrapper pt-5 justify-end items-start">
                   <Tag size="big" style="retro" background="dark" className="py-2">
                     {item.title}
                   </Tag>


### PR DESCRIPTION
## #️⃣연관된 이슈

#166 

## 📝작업 내용

회원가입 페이지에 들어갔다가 나오면, HeroSwiperBanner의 태그 컴포넌트가 아래로 길어지는 애니메이션이 적용되는 버그가 있었습니다.
해당 태그가 사용된 요소의 css에 `items-start` 적용하여 해결했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
