### PR TITLE
feat: 길드 이미지 업로드 api

### DIFF
--- a/src/api/guild.ts
+++ b/src/api/guild.ts
@@ -11,11 +11,11 @@ import {
   GuildAdminResponse,
 } from '@/types/guildApi';
 import categorizeTags from '@/utils/categorizeTags';
+import { uploadToS3 } from '@/utils/uploadToS3';
 
 export const useGuild = () => {
   const axios = useAxios();
 
-  // ✅ 파싱 완료, 테스트 완료
   async function GetGuild(guildId: string) {
     const response = await axios.TypedGet<GuildDetailResponse>(GUILD.detail(guildId), {}, true);
     const data = response?.data;
@@ -41,7 +41,6 @@ export const useGuild = () => {
     return null;
   }
 
-  // ✅ 테스트 완료
   async function UpdateGuild(guildId: string, newData: GuildUpdateRequest) {
     const response = await axios.Put(GUILD.modify(guildId), newData, {}, true);
     const data = response?.data;
@@ -52,7 +51,6 @@ export const useGuild = () => {
     return data;
   }
 
-  // ✅ 테스트 완료
   async function DeleteGuild(guildId: string) {
     const response = await axios.Delete(GUILD.delete(guildId), {}, true);
     const data = response?.data;
@@ -63,7 +61,6 @@ export const useGuild = () => {
     return data;
   }
 
-  // ❌ 테스트 실패
   async function GetGuildList(request: GuildLIstRequest, page?: number, pageSize?: number, sort?: Sort) {
     const response = await axios.Post(
       GUILD.list,
@@ -103,22 +100,41 @@ export const useGuild = () => {
     return null;
   }
 
-  // ✅  테스트 완료
   async function CreateGuild(newData: GuildCreateRequest) {
     try {
       const response = await axios.Post(GUILD.create, newData, {}, true);
       const data = response?.data.data;
       console.log(data);
-      if (data) {
-        alert('길드가 생성되었습니다!');
-      }
-      return data;
+      return { guildId: data.id, presignedUrl: data.presignedUrl };
     } catch (error) {
       console.log(error);
     }
   }
 
-  // ✅  테스트 완료
+  async function CreateGuildWithImg(newData: GuildCreateRequest, imageFile: File | null) {
+    try {
+      // 1. 길드 생성
+      const createResponse = await CreateGuild(newData);
+      if (createResponse && imageFile) {
+        const { guildId, presignedUrl } = createResponse;
+        // 2. S3 presigned URL로 이미지 업로드
+        const s3Response = await uploadToS3(imageFile, presignedUrl);
+        if (s3Response.success) {
+          const imageUrl = s3Response.url;
+          console.log('이미지 업로드 완료: ', imageUrl);
+          // 3. 이미지 URL 서버에 등록
+          await UploadImageURL(guildId, imageUrl);
+          console.log('길드 생성 완료(이미지O)');
+          return true;
+        }
+      }
+      console.log('길드 생성 완료(이미지X)');
+      return true;
+    } catch (error) {
+      console.log('길드 생성 중 오류 발생: ', error);
+    }
+  }
+
   async function GetAdmin(guildId: string) {
     const response = await axios.TypedGet<GuildAdminResponse>(GUILD.admin(guildId), {}, true);
     const data = response?.data;
@@ -145,20 +161,21 @@ export const useGuild = () => {
     return null;
   }
 
-  //
   async function GetGuildMembers(guildId: string) {
     const response = await axios.TypedGet<GuildDetailMemberResponse>(GUILD.detail_member(guildId), {}, true);
     const data = response?.data;
     console.log(data);
   }
 
-  // ❌ 테스트 불가 (로직 수정 중)
   async function UploadImageURL(guildId: string, url: string) {
-    const response = await axios.Post(GUILD.upload_image(guildId), { url }, {}, true);
+    const response = await axios.PostText(GUILD.upload_image(guildId), url, {}, true);
     console.log(response);
+    if (response?.status === 204) {
+      return true;
+    }
+    return false;
   }
 
-  // ✅ 파싱 완료, 테스트 완료
   async function GetGuildRecommend(appid: string, count?: number) {
     const response = await axios.TypedGet<GuildMainResponse>(
       GUILD.recommend,
@@ -196,7 +213,6 @@ export const useGuild = () => {
     return null;
   }
 
-  // ✅ 파싱 완료, 테스트 완료
   async function GetGuildPopular() {
     const response = await axios.TypedGet<GuildMainResponse>(GUILD.popular, {}, true);
     const data = response?.data;
@@ -236,5 +252,6 @@ export const useGuild = () => {
     GetGuildMembers,
     GetGuildRecommend,
     GetGuildPopular,
+    CreateGuildWithImg,
   };
 };

--- a/src/api/guild.ts
+++ b/src/api/guild.ts
@@ -42,13 +42,14 @@ export const useGuild = () => {
   }
 
   async function UpdateGuild(guildId: string, newData: GuildUpdateRequest) {
-    const response = await axios.Put(GUILD.modify(guildId), newData, {}, true);
-    const data = response?.data;
-    if (data.msg === 'OK') {
-      alert('수정되었습니다!');
+    try {
+      const response = await axios.Put(GUILD.modify(guildId), newData, {}, true);
+      const data = response?.data.data;
+      console.log(data);
+      return { guildId: data.id, presignedUrl: data.presignedUrl };
+    } catch (error) {
+      console.log(error);
     }
-    console.log(data);
-    return data;
   }
 
   async function DeleteGuild(guildId: string) {
@@ -132,6 +133,29 @@ export const useGuild = () => {
       return true;
     } catch (error) {
       console.log('길드 생성 중 오류 발생: ', error);
+    }
+  }
+  async function UpdateGuildWithImg(guildId: string, newData: GuildUpdateRequest, imageFile: File | null) {
+    try {
+      // 1. 길드 수정
+      const updateResponse = await UpdateGuild(guildId, newData);
+      if (updateResponse && imageFile) {
+        const { guildId, presignedUrl } = updateResponse;
+        // 2. S3 presigned URL로 이미지 업로드
+        const s3Response = await uploadToS3(imageFile, presignedUrl);
+        if (s3Response.success) {
+          const imageUrl = s3Response.url;
+          console.log('이미지 업로드 완료: ', imageUrl);
+          // 3. 이미지 URL 서버에 등록
+          await UploadImageURL(guildId, imageUrl);
+          console.log('길드 수정 완료(이미지O)');
+          return true;
+        }
+      }
+      console.log('길드 수정 완료(이미지X)');
+      return true;
+    } catch (error) {
+      console.log('길드 수정 중 오류 발생: ', error);
     }
   }
 
@@ -253,5 +277,6 @@ export const useGuild = () => {
     GetGuildRecommend,
     GetGuildPopular,
     CreateGuildWithImg,
+    UpdateGuildWithImg,
   };
 };

--- a/src/app/guild/test/page.tsx
+++ b/src/app/guild/test/page.tsx
@@ -1,23 +1,49 @@
 'use client';
 
+import { useGuild } from '@/api/guild';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { uploadToS3 } from '@/utils/uploadToS3';
-import { ChangeEvent } from 'react';
+import { GuildCreateRequest } from '@/types/guildApi';
+import { ChangeEvent, useState } from 'react';
 
 export default function Test() {
-  const presignedUrl =
-    'https://test-bucket.s3.ap-northeast-2.amazonaws.com/guild/6553/f55d1eb1-65d6-44bf-969e-c928e6515c6a.webp?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20250410T054741Z&X-Amz-SignedHeaders=host&X-Amz-Credential=test-access-key%2F20250410%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Expires=180&X-Amz-Signature=a567ed389c8cdeed89f3609cd2a99625de1651876ee6a5ef7a016bbea114d107';
+  const Guild = useGuild();
+  const [image, setImage] = useState<File | null>(null);
+
+  const newData_create: GuildCreateRequest = {
+    name: '최종 테스트12 이미지 있음',
+    description: '테스트입니다.',
+    maxMembers: 3,
+    isPublic: true,
+    appid: 1,
+    fileType: 'webp',
+    tags: [
+      { type: '파티 스타일', value: '스피드러너' },
+      { type: '파티 스타일', value: '맛보기' },
+      { type: '게임 실력', value: '마스터' },
+      { type: '성별', value: '여자만' },
+      { type: '친목', value: '친목 환영' },
+    ],
+  };
+
+  const createGuild = async () => {
+    await Guild.CreateGuildWithImg(newData_create, image);
+    // console.log(response);
+  };
+
   const handleChange = async (e: ChangeEvent<HTMLInputElement>) => {
-    const data = e.target.files;
-    if (data && data.length > 0) {
-      console.log(data[0]);
-      const response = await uploadToS3(data[0], presignedUrl);
-      console.log(response);
+    if (e.target.files) {
+      setImage(e.target.files[0]);
+      console.log(e.target.files[0]);
     }
   };
+
   return (
     <div className="wrapper mt-32">
       <Input type="file" onChange={handleChange} className="w-[500px]" />
+      <div className="inline-flex flex-col gap-5 mt-6">
+        <Button onClick={createGuild}>길드 생성</Button>
+      </div>
     </div>
   );
 }

--- a/src/app/guild/test/page.tsx
+++ b/src/app/guild/test/page.tsx
@@ -3,7 +3,7 @@
 import { useGuild } from '@/api/guild';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { GuildCreateRequest } from '@/types/guildApi';
+import { GuildCreateRequest, GuildUpdateRequest } from '@/types/guildApi';
 import { ChangeEvent, useState } from 'react';
 
 export default function Test() {
@@ -26,8 +26,29 @@ export default function Test() {
     ],
   };
 
+  const newData_update: GuildUpdateRequest = {
+    name: '테스트 수정입니다 다시 다시 시도',
+    description: 'test2 test2',
+    maxMembers: 3,
+    isPublic: true,
+    appid: 1,
+    newFileType: 'jpg',
+    tags: [
+      { type: '파티 스타일', value: '스피드러너' },
+      { type: '파티 스타일', value: '맛보기' },
+      { type: '게임 실력', value: '마스터' },
+      { type: '성별', value: '여자만' },
+      { type: '친목', value: '친목 환영' },
+      { type: '게임 실력', value: '해커' },
+    ],
+  };
+
   const createGuild = async () => {
     await Guild.CreateGuildWithImg(newData_create, image);
+    // console.log(response);
+  };
+  const updateGuild = async () => {
+    await Guild.UpdateGuildWithImg('53', newData_update, image);
     // console.log(response);
   };
 
@@ -43,6 +64,7 @@ export default function Test() {
       <Input type="file" onChange={handleChange} className="w-[500px]" />
       <div className="inline-flex flex-col gap-5 mt-6">
         <Button onClick={createGuild}>길드 생성</Button>
+        <Button onClick={updateGuild}>53번 길드 수정</Button>
       </div>
     </div>
   );

--- a/src/hooks/useAxios.ts
+++ b/src/hooks/useAxios.ts
@@ -71,11 +71,21 @@ export const useAxios = () => {
     }
   }
 
+  async function PostText(path: string, data: string, config: AxiosRequestConfig, toast: boolean) {
+    try {
+      const response = await apiInstance.post(path, data, { headers: { 'Content-Type': 'text/plain' }, ...config });
+      return response;
+    } catch (err) {
+      errorHandler(err, toast);
+    }
+  }
+
   return {
     Get,
     Delete,
     Post,
     Put,
     TypedGet,
+    PostText,
   };
 };

--- a/src/types/guildApi.ts
+++ b/src/types/guildApi.ts
@@ -1,4 +1,4 @@
-type FileType = 'png' | 'jpg' | 'jpeg' | 'webp';
+type FileType = 'png' | 'jpg' | 'jpeg' | 'webp' | '';
 
 export type Sort = 'latest' | 'activity' | 'members';
 

--- a/src/utils/uploadToS3.ts
+++ b/src/utils/uploadToS3.ts
@@ -4,17 +4,13 @@ export async function uploadToS3(
   imageFile: File,
   s3Url: string
 ): Promise<{ success: true; url: string } | { success: false; url: null }> {
-  // return {
-  //   success: true,
-  //   url: new URL(s3Url).origin + '/' + imageFile.name,
-  // };
-
   const response = await axios.put(s3Url, imageFile, { headers: { 'Content-Type': imageFile.type } });
-  if ((response && response.status === 200) || response.status === 201) {
-    console.log(response);
+
+  if (response.config.url && (response.status === 200 || response.status === 201)) {
+    // console.log(response.config.url.split('?')[0]);
     return {
       success: true,
-      url: new URL(s3Url).origin + imageFile.name,
+      url: response.config.url?.split('?')[0],
     };
   }
   return { success: false, url: null };


### PR DESCRIPTION
## #️⃣연관된 이슈

#190 

## 📝작업 내용

### 이미지 업로드 로직
**1. 길드 생성하고 이미지 있을 경우 presignedUrl 받기**
   - POST`/api/guilds`로 길드 생성 요청을 보내고, 응답으로 presignedUrl을 받음
   - 요청을 보낼때, data에 fileType을 담아서 보내야함 (`'png' | 'jpg' | 'jpeg' | 'webp' | ''`)
   - 이미지 없을 시, 빈 값이나 null로 요청을 보내면 되고, 그 때에는 presignedUrl도 null 값으로 돌아옴
 
**2. S3에 이미지 업로드 하고 업로드한 url 받기**
   - uploadToS3 함수에 업로드할 이미지 File과 1번에서 받은 presignedUrl을 전달하여 이미지 업로드 하기 (**이미지는 꼭 File 타입이여야 함!**)
   - 응답으로 업로드 한 이미지의 url이 돌아옴

**3. 백엔드 서버에 이미지 url 업로드 하기**
   - 2번에서 받아온 이미지 url을  POST`/api/guilds/{guildId}/img` 엔드포인트로 전달
   (이 단계에서 post 요청의 data에 string 값만 넣어야 해서 useAxios에 새로운 함수 생성함(아래 참고))


**수정사항**
- s3에 이미지 업로드 후 받아온 url을 서버에 보내는  Post`/api/guilds/{guildId}/img` 에서 data에 object가 아닌 string만 전달해주어야해서 useAxios에 PostText 함수 추가로 생성했습니다.
- useGuild에 길드 생성&수정 및 이미지 업로드 로직을 한 번에 해주는 `CreateGuildWithImg`, `UpdateGuildWithImg` 함수 두 개 추가로 구현 해두었습니다.  

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
