### PR TITLE
feat: 길드 메인 페이지 일부와 길드 상세 페이지 연동

### DIFF
--- a/src/api/guild.ts
+++ b/src/api/guild.ts
@@ -276,7 +276,7 @@ export const useGuild = () => {
           guild_id: item.guildId,
           guild_name: item.name,
           description: item.description,
-          img_src: item.guildImg || 'https://placehold.co/600x400?text=PlayOn+Guild',
+          img_src: item.guildImg,
           num_members: item.memberCount,
           max_members: item.memberCount,
           owner: { username: 'test', nickname: 'test', user_title: 'title', img_src: 'test' },
@@ -288,7 +288,7 @@ export const useGuild = () => {
           friendly: tags.friendly,
         };
       });
-      // console.log(guildList);
+      console.log('GuildPopular', guildList);
       return guildList;
     }
     console.log('데이터가 없습니다.');
@@ -310,16 +310,3 @@ export const useGuild = () => {
     UpdateGuildWithImg,
   };
 };
-
-// const [{
-//   data: guildData,
-//   isLoading,
-//   isError,
-// },{data: guildMemberData, isLoading, isError}] = useSuspenseQueries({
-//   queryKey: ['GuildDetail'],
-//   queryFn: () => Guild.GetGuild(guildId),
-// });
-
-// const getTagList = (data: guild) => {
-//   return [...data.friendly, ...data.gender, ...data.play_style, ...data.skill_level];
-// };

--- a/src/api/guild.ts
+++ b/src/api/guild.ts
@@ -23,6 +23,7 @@ export const useGuild = () => {
     if (data) {
       const tags = categorizeTags(data?.tags);
       const guildDetail: guild = {
+        guild_id: data.id,
         guild_name: data?.name,
         description: data?.description,
         img_src: data?.guildImg,
@@ -82,6 +83,7 @@ export const useGuild = () => {
       const guildList: guild[] = data.map((item: GuildSimple) => {
         const tags = categorizeTags(item.tags);
         return {
+          guild_id: item.guildId,
           guild_name: item.name,
           description: item.description,
           img_src: item.guildImg,
@@ -172,6 +174,7 @@ export const useGuild = () => {
     if (data) {
       const tags = categorizeTags(data.tags);
       const guildDetail: guild & { managerNames: string[] } = {
+        guild_id: data.id,
         guild_name: data?.name,
         description: 'test',
         img_src: data?.guildImg,
@@ -224,6 +227,7 @@ export const useGuild = () => {
       const guildList: guild[] = data.map((item) => {
         const tags = categorizeTags(item.tags);
         return {
+          guild_id: item.guildId,
           guild_name: item.name,
           description: item.description,
           img_src: item.guildImg,
@@ -252,9 +256,10 @@ export const useGuild = () => {
       const guildList: guild[] = data.map((item) => {
         const tags = categorizeTags(item.tags);
         return {
+          guild_id: item.guildId,
           guild_name: item.name,
           description: item.description,
-          img_src: item.guildImg,
+          img_src: item.guildImg || 'https://placehold.co/600x400?text=PlayOn+Guild',
           num_members: item.memberCount,
           owner: { username: 'test', nickname: 'test', user_title: 'title', img_src: 'test' },
           created_at: new Date(1),
@@ -265,7 +270,7 @@ export const useGuild = () => {
           friendly: tags.friendly,
         };
       });
-      console.log(guildList);
+      // console.log(guildList);
       return guildList;
     }
     console.log('데이터가 없습니다.');

--- a/src/api/guild.ts
+++ b/src/api/guild.ts
@@ -16,7 +16,7 @@ import { uploadToS3 } from '@/utils/uploadToS3';
 export const useGuild = () => {
   const axios = useAxios();
 
-  async function GetGuild(guildId: number) {
+  async function GetGuild(guildId: string) {
     const response = await axios.TypedGet<GuildDetailResponse>(GUILD.detail(guildId), {}, true);
     const data = response?.data;
     console.log(data);
@@ -24,10 +24,11 @@ export const useGuild = () => {
       const tags = categorizeTags(data?.tags);
       const guildDetail: guild = {
         guild_id: data.id,
-        guild_name: data?.name,
-        description: data?.description,
-        img_src: data?.guildImg,
-        num_members: data?.memberCount,
+        guild_name: data.name,
+        description: data.description,
+        img_src: data.guildImg || '/img/hero/bg_community_main.webp',
+        num_members: data.memberCount,
+        max_members: data.maxMembers,
         owner: { username: 'test', nickname: data.leaderName, user_title: 'title', img_src: data.leaderImg },
         created_at: new Date(data.createdAt),
         myRole: data.myRole,
@@ -39,10 +40,10 @@ export const useGuild = () => {
       console.log(guildDetail);
       return guildDetail;
     }
-    return null;
+    throw Error;
   }
 
-  async function UpdateGuild(guildId: number, newData: GuildUpdateRequest) {
+  async function UpdateGuild(guildId: string, newData: GuildUpdateRequest) {
     try {
       const response = await axios.Put(GUILD.modify(guildId), newData, {}, true);
       const data = response?.data.data;
@@ -53,7 +54,7 @@ export const useGuild = () => {
     }
   }
 
-  async function DeleteGuild(guildId: number) {
+  async function DeleteGuild(guildId: string) {
     const response = await axios.Delete(GUILD.delete(guildId), {}, true);
     const data = response?.data;
     if (data.msg === 'OK') {
@@ -143,7 +144,7 @@ export const useGuild = () => {
       console.log('길드 생성 중 오류 발생: ', error);
     }
   }
-  async function UpdateGuildWithImg(guildId: number, newData: GuildUpdateRequest, imageFile: File | null) {
+  async function UpdateGuildWithImg(guildId: string, newData: GuildUpdateRequest, imageFile: File | null) {
     try {
       // 1. 길드 수정
       const updateResponse = await UpdateGuild(guildId, newData);
@@ -167,7 +168,7 @@ export const useGuild = () => {
     }
   }
 
-  async function GetAdmin(guildId: number) {
+  async function GetAdmin(guildId: string) {
     const response = await axios.TypedGet<GuildAdminResponse>(GUILD.admin(guildId), {}, true);
     const data = response?.data;
     // console.log(data);
@@ -177,8 +178,9 @@ export const useGuild = () => {
         guild_id: data.id,
         guild_name: data?.name,
         description: 'test',
-        img_src: data?.guildImg,
-        num_members: data?.memberCount,
+        img_src: data.guildImg,
+        num_members: data.memberCount,
+        max_members: data.memberCount,
         owner: { username: 'test', nickname: data.leaderName, user_title: 'title', img_src: '' },
         created_at: new Date(data.createdAt),
         myRole: data.myRole,
@@ -194,14 +196,14 @@ export const useGuild = () => {
     return null;
   }
 
-  async function GetGuildMembers(guildId: number) {
+  async function GetGuildMembers(guildId: string) {
     const response = await axios.TypedGet<GuildDetailMemberResponse>(GUILD.detail_member(guildId), {}, true);
     const data = response?.data;
     console.log(data);
     return data;
   }
 
-  async function UploadImageURL(guildId: number, url: string) {
+  async function UploadImageURL(guildId: string, url: string) {
     const response = await axios.Post(GUILD.upload_image(guildId), { url: url }, {}, true);
     console.log(response);
     if (response?.status === 204) {
@@ -232,6 +234,7 @@ export const useGuild = () => {
           description: item.description,
           img_src: item.guildImg,
           num_members: item.memberCount,
+          max_members: item.memberCount,
           owner: { username: 'test', nickname: 'test', user_title: 'title', img_src: 'test' },
           created_at: new Date(1),
           myRole: 'test',
@@ -261,6 +264,7 @@ export const useGuild = () => {
           description: item.description,
           img_src: item.guildImg || 'https://placehold.co/600x400?text=PlayOn+Guild',
           num_members: item.memberCount,
+          max_members: item.memberCount,
           owner: { username: 'test', nickname: 'test', user_title: 'title', img_src: 'test' },
           created_at: new Date(1),
           myRole: 'test',
@@ -292,3 +296,16 @@ export const useGuild = () => {
     UpdateGuildWithImg,
   };
 };
+
+// const [{
+//   data: guildData,
+//   isLoading,
+//   isError,
+// },{data: guildMemberData, isLoading, isError}] = useSuspenseQueries({
+//   queryKey: ['GuildDetail'],
+//   queryFn: () => Guild.GetGuild(guildId),
+// });
+
+// const getTagList = (data: guild) => {
+//   return [...data.friendly, ...data.gender, ...data.play_style, ...data.skill_level];
+// };

--- a/src/api/guild.ts
+++ b/src/api/guild.ts
@@ -40,7 +40,7 @@ export const useGuild = () => {
       console.log(guildDetail);
       return guildDetail;
     }
-    throw Error;
+    return false;
   }
 
   async function UpdateGuild(guildId: string, newData: GuildUpdateRequest) {
@@ -198,9 +198,23 @@ export const useGuild = () => {
 
   async function GetGuildMembers(guildId: string) {
     const response = await axios.TypedGet<GuildDetailMemberResponse>(GUILD.detail_member(guildId), {}, true);
+    console.log(response);
     const data = response?.data;
     console.log(data);
-    return data;
+    if (response && data && data.length > 0) {
+      const guildMemberList = data.map((member) => {
+        return {
+          username: member.username,
+          title: member.title,
+          role: member.role,
+          img_src: member.profileImg || 'https://placehold.co/200',
+          member_id: member.memberId,
+          joined_at: new Date(member.joinedAt),
+        };
+      });
+      return guildMemberList;
+    }
+    return false;
   }
 
   async function UploadImageURL(guildId: string, url: string) {

--- a/src/api/guildBoard.ts
+++ b/src/api/guildBoard.ts
@@ -1,5 +1,6 @@
 import { GUILD_BOARD_ENDPOINTS } from '@/constants/endpoints/guild-board';
 import { useAxios } from '@/hooks/useAxios';
+import { postSimple } from '@/types/community';
 import { uploadToS3 } from '@/utils/uploadToS3';
 // import { guildCommunityTags } from '@/types/Tags/communityTags';
 
@@ -211,7 +212,22 @@ export const useGuildBoard = () => {
   async function GuildNoticesPost(guildId: number) {
     const response = await axios.Get(GUILD_BOARD_ENDPOINTS.guildNoticesPost(guildId), {}, true);
     if (response && response.status === 200) {
-      return response.data.data as noticesPost[];
+      // return response.data.data as noticesPost[];
+      const data = response.data.data as noticesPost[];
+      const postData = data.map((post) => {
+        return {
+          postId: post.id,
+          author_nickname: post.authorNickname,
+          author_img: post.authorAvatar,
+          title: post.title,
+          content: post.content,
+          img_src: post.imageUrl,
+          num_likes: post.likeCount,
+          comments_num: post.commentCount,
+          tag: '공지',
+        };
+      });
+      return postData as postSimple[];
     }
     return false;
   }
@@ -219,7 +235,22 @@ export const useGuildBoard = () => {
   async function GuildLatestPost(guildId: number) {
     const response = await axios.Get(GUILD_BOARD_ENDPOINTS.guildLatestPost(guildId), {}, true);
     if (response && response.status === 200) {
-      return response.data.data as noticesPost;
+      // return response.data.data as noticesPost[];
+      const data = response.data.data as noticesPost[];
+      const postData = data.map((post) => {
+        return {
+          postId: post.id,
+          author_nickname: post.authorNickname,
+          author_img: post.authorAvatar,
+          title: post.title,
+          content: post.content,
+          img_src: post.imageUrl,
+          num_likes: post.likeCount,
+          comments_num: post.commentCount,
+          tag: '자유',
+        };
+      });
+      return postData as postSimple[];
     }
     return false;
   }

--- a/src/api/guildBoard.ts
+++ b/src/api/guildBoard.ts
@@ -230,6 +230,7 @@ export const useGuildBoard = () => {
       return postData as postSimple[];
     }
     return false;
+    // throw new Error('Fail to fetch');
   }
 
   async function GuildLatestPost(guildId: number) {

--- a/src/app/guild/[guildid]/components/GuildBoardLatestSection.tsx
+++ b/src/app/guild/[guildid]/components/GuildBoardLatestSection.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useGuildBoard } from '@/api/guildBoard';
+import CommunityPostImageShort from '@/components/community/post-image-short';
+import CommunityPostShort from '@/components/community/post-short';
+import { PATH } from '@/constants/routes';
+import { useQuery } from '@tanstack/react-query';
+import { ChevronRight } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+export default function GuildBoardLatestSection({ guildId }: { guildId: string }) {
+  const guildid = Number(guildId);
+  const GuildBoard = useGuildBoard();
+  const router = useRouter();
+
+  const { data: guildBoardData } = useQuery({
+    queryKey: ['GuildBoard', guildId],
+    queryFn: () => GuildBoard.GuildLatestPost(guildid),
+  });
+
+  return (
+    <div className="flex flex-col gap-6 w-[67%] self-center">
+      <div className="flex w-full justify-between">
+        <p className="text-4xl font-bold text-neutral-900">길드 최신글</p>
+        <div
+          className="flex items-center cursor-pointer"
+          onClick={() => router.push(`${PATH.guild_community(guildId)}`)}
+        >
+          <p className="text-xl font-medium text-neutral-900">전체 보기</p>
+          <ChevronRight />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-6">
+        {guildBoardData &&
+          guildBoardData.map((post) => {
+            if (post.img_src) {
+              return <CommunityPostImageShort key={post.postId} data={post} className="h-52 cursor-pointer" />;
+            } else {
+              return <CommunityPostShort key={post.postId} data={post} className="h-52 cursor-pointer" />;
+            }
+          })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/guild/[guildid]/components/GuildBoardLatestSection.tsx
+++ b/src/app/guild/[guildid]/components/GuildBoardLatestSection.tsx
@@ -1,22 +1,20 @@
 'use client';
 
-import { useGuildBoard } from '@/api/guildBoard';
 import CommunityPostImageShort from '@/components/community/post-image-short';
 import CommunityPostShort from '@/components/community/post-short';
 import { PATH } from '@/constants/routes';
-import { useQuery } from '@tanstack/react-query';
+import { postSimple } from '@/types/community';
 import { ChevronRight } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
-export default function GuildBoardLatestSection({ guildId }: { guildId: string }) {
-  const guildid = Number(guildId);
-  const GuildBoard = useGuildBoard();
+export default function GuildBoardLatestSection({
+  guildId,
+  guildBoardLatest,
+}: {
+  guildId: string;
+  guildBoardLatest: postSimple[];
+}) {
   const router = useRouter();
-
-  const { data: guildBoardData } = useQuery({
-    queryKey: ['GuildBoard', guildId],
-    queryFn: () => GuildBoard.GuildLatestPost(guildid),
-  });
 
   return (
     <div className="flex flex-col gap-6 w-[67%] self-center">
@@ -31,8 +29,8 @@ export default function GuildBoardLatestSection({ guildId }: { guildId: string }
         </div>
       </div>
       <div className="grid grid-cols-2 gap-x-6 gap-y-6">
-        {guildBoardData &&
-          guildBoardData.map((post) => {
+        {guildBoardLatest &&
+          guildBoardLatest.map((post) => {
             if (post.img_src) {
               return <CommunityPostImageShort key={post.postId} data={post} className="h-52 cursor-pointer" />;
             } else {

--- a/src/app/guild/[guildid]/components/GuildBoardNoticeSection.tsx
+++ b/src/app/guild/[guildid]/components/GuildBoardNoticeSection.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { useGuildBoard } from '@/api/guildBoard';
+import CommunityPostImageLong from '@/components/community/post-image-long';
+import CommunityPostLong from '@/components/community/post-long';
+import { PATH } from '@/constants/routes';
+import { useQuery } from '@tanstack/react-query';
+import { ChevronRight } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+export default function GuildBoardNoticeSection({ guildId }: { guildId: string }) {
+  const guildid = Number(guildId);
+  const GuildBoard = useGuildBoard();
+  const router = useRouter();
+
+  const { data: guildBoardData } = useQuery({
+    queryKey: ['GuildBoardNotice', guildId],
+    queryFn: () => GuildBoard.GuildNoticesPost(guildid),
+  });
+  return (
+    <div className="flex flex-col w-[67%] self-center">
+      <div className="flex w-full justify-between">
+        <p className="text-4xl font-bold text-neutral-900">공지</p>
+        <div
+          className="flex items-center cursor-pointer"
+          onClick={() => router.push(`${PATH.guild_community(guildId)}?tag=공지`)}
+        >
+          <p className="text-xl font-medium text-neutral-900">전체 보기</p>
+          <ChevronRight />
+        </div>
+      </div>
+      <div className="flex flex-col divide-y divide-neutral-200">
+        {guildBoardData && guildBoardData[0] && (
+          <CommunityPostImageLong
+            data={guildBoardData[0]}
+            className="h-44 "
+            onClick={() => {
+              router.push(PATH.guild_community_detail(guildId, String(guildBoardData[0].postId)));
+            }}
+          />
+        )}
+        {guildBoardData && guildBoardData[1] && (
+          <CommunityPostLong
+            data={guildBoardData[1]}
+            className="h-44"
+            onClick={() => {
+              router.push(PATH.guild_community_detail(guildId, String(guildBoardData[1].postId)));
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/guild/[guildid]/components/GuildBoardNoticeSection.tsx
+++ b/src/app/guild/[guildid]/components/GuildBoardNoticeSection.tsx
@@ -1,21 +1,19 @@
 'use client';
-import { useGuildBoard } from '@/api/guildBoard';
 import CommunityPostImageLong from '@/components/community/post-image-long';
 import CommunityPostLong from '@/components/community/post-long';
 import { PATH } from '@/constants/routes';
-import { useQuery } from '@tanstack/react-query';
+import { postSimple } from '@/types/community';
 import { ChevronRight } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
-export default function GuildBoardNoticeSection({ guildId }: { guildId: string }) {
-  const guildid = Number(guildId);
-  const GuildBoard = useGuildBoard();
+export default function GuildBoardNoticeSection({
+  guildId,
+  guildBoardNotice,
+}: {
+  guildId: string;
+  guildBoardNotice: postSimple[];
+}) {
   const router = useRouter();
-
-  const { data: guildBoardData } = useQuery({
-    queryKey: ['GuildBoardNotice', guildId],
-    queryFn: () => GuildBoard.GuildNoticesPost(guildid),
-  });
   return (
     <div className="flex flex-col w-[67%] self-center">
       <div className="flex w-full justify-between">
@@ -29,21 +27,21 @@ export default function GuildBoardNoticeSection({ guildId }: { guildId: string }
         </div>
       </div>
       <div className="flex flex-col divide-y divide-neutral-200">
-        {guildBoardData && guildBoardData[0] && (
+        {guildBoardNotice && guildBoardNotice[0] && (
           <CommunityPostImageLong
-            data={guildBoardData[0]}
+            data={guildBoardNotice[0]}
             className="h-44 "
             onClick={() => {
-              router.push(PATH.guild_community_detail(guildId, String(guildBoardData[0].postId)));
+              router.push(PATH.guild_community_detail(guildId, String(guildBoardNotice[0].postId)));
             }}
           />
         )}
-        {guildBoardData && guildBoardData[1] && (
+        {guildBoardNotice && guildBoardNotice[1] && (
           <CommunityPostLong
-            data={guildBoardData[1]}
+            data={guildBoardNotice[1]}
             className="h-44"
             onClick={() => {
-              router.push(PATH.guild_community_detail(guildId, String(guildBoardData[1].postId)));
+              router.push(PATH.guild_community_detail(guildId, String(guildBoardNotice[1].postId)));
             }}
           />
         )}

--- a/src/app/guild/[guildid]/components/GuildInfoSection.tsx
+++ b/src/app/guild/[guildid]/components/GuildInfoSection.tsx
@@ -1,22 +1,16 @@
 'use client';
 
-import { useGuild } from '@/api/guild';
 import RetroButton from '@/components/common/RetroButton';
 import Tag from '@/components/common/Tag';
 import GhostSVG from '@/components/svg/ghost_fill';
 import { Button } from '@/components/ui/button';
+import { PATH } from '@/constants/routes';
 import { guild } from '@/types/guild';
-import { useQuery } from '@tanstack/react-query';
 import { ClipboardPenIcon } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 
-export default function GuildInfoSection({ guildId }: { guildId: string }) {
-  const Guild = useGuild();
-
-  const { data: guildData } = useQuery({
-    queryKey: ['GuildDetail', guildId],
-    queryFn: () => Guild.GetGuild(guildId),
-  });
-
+export default function GuildInfoSection({ guildData }: { guildData: guild }) {
+  const router = useRouter();
   const getTagList = (data: guild) => {
     return [...data.friendly, ...data.gender, ...data.play_style, ...data.skill_level];
   };
@@ -30,7 +24,11 @@ export default function GuildInfoSection({ guildId }: { guildId: string }) {
               className=" size-full rounded-3xl bg-center bg-cover"
             />
             {(guildData.myRole === 'LEADER' || guildData.myRole === 'MANAGER') && (
-              <Button variant="outline" className="w-fit px-4 py-2 text-neutral-500">
+              <Button
+                variant="outline"
+                className="w-fit px-4 py-2 text-neutral-500"
+                onClick={() => router.push(PATH.guild_admin(String(guildData.guild_id)))}
+              >
                 <ClipboardPenIcon />
                 <span>길드 관리</span>
               </Button>

--- a/src/app/guild/[guildid]/components/GuildInfoSection.tsx
+++ b/src/app/guild/[guildid]/components/GuildInfoSection.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useGuild } from '@/api/guild';
+import RetroButton from '@/components/common/RetroButton';
+import Tag from '@/components/common/Tag';
+import GhostSVG from '@/components/svg/ghost_fill';
+import { Button } from '@/components/ui/button';
+import { guild } from '@/types/guild';
+import { useQuery } from '@tanstack/react-query';
+import { ClipboardPenIcon } from 'lucide-react';
+
+export default function GuildInfoSection({ guildId }: { guildId: string }) {
+  const Guild = useGuild();
+
+  const { data: guildData } = useQuery({
+    queryKey: ['GuildDetail', guildId],
+    queryFn: () => Guild.GetGuild(guildId),
+  });
+
+  const getTagList = (data: guild) => {
+    return [...data.friendly, ...data.gender, ...data.play_style, ...data.skill_level];
+  };
+  return (
+    <>
+      {guildData && (
+        <div className="flex gap-6 w-[67%] self-center">
+          <div className="flex flex-col gap-4 min-w-[628px] aspect-[16/7]">
+            <div
+              style={{ backgroundImage: `url(${guildData.img_src})` }}
+              className=" size-full rounded-3xl bg-center bg-cover"
+            />
+            {(guildData.myRole === 'LEADER' || guildData.myRole === 'MANAGER') && (
+              <Button variant="outline" className="w-fit px-4 py-2 text-neutral-500">
+                <ClipboardPenIcon />
+                <span>길드 관리</span>
+              </Button>
+            )}
+          </div>
+          <div className="flex flex-col gap-5">
+            <p className="font-bold text-5xl text-neutral-900">{guildData.guild_name}</p>
+            <div className="flex gap-2">
+              {getTagList(guildData).map((e, ind) => (
+                <Tag style="retro" size="small" background="dark" className="" key={ind}>
+                  {e}
+                </Tag>
+              ))}
+            </div>
+            <p className="text-sm text-neutral-900 font-medium line-clamp-4 text-ellipsis">{guildData.description}</p>
+            <div className="flex gap-6">
+              <div className="w-36 py-5 bg-neutral-100 rounded-lg aspect-square flex flex-col items-center justify-start gap-2">
+                <p className="font-semibold">CAPTAIN</p>
+                {guildData.owner.img_src ? (
+                  <img src={guildData.owner.img_src} alt="" className="w-12 rounded-full object-cover" />
+                ) : (
+                  <div className="bg-purple-300 size-12 rounded-full flex justify-center items-center">
+                    <GhostSVG width={24} fill="#FFFFFF" stroke="" />
+                  </div>
+                )}
+                <p>{guildData.owner.nickname}</p>
+              </div>
+              <div className="w-36 py-5 bg-neutral-100 rounded-lg aspect-square flex flex-col items-center justify-start gap-5">
+                <p className="font-semibold">MEMBERS</p>
+                <p>
+                  <span className="text-4xl font-extrabold">{`${guildData.num_members}`}</span>
+                  <span>{`/ ${guildData.max_members}`}</span>
+                </p>
+              </div>
+            </div>
+            {guildData.myRole === 'GUEST' ? (
+              <RetroButton type="purple" className="w-60">
+                길드 참여
+              </RetroButton>
+            ) : (
+              <RetroButton type="purple" className="w-60">
+                길드 탈퇴
+              </RetroButton>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/guild/[guildid]/components/GuildInfoSectionSkeleton.tsx
+++ b/src/app/guild/[guildid]/components/GuildInfoSectionSkeleton.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function GuildInfoSectionSkeleton() {
+  return (
+    <div className="flex gap-6 w-[67%] self-center">
+      <div className="flex flex-col gap-4 min-w-[628px] aspect-[16/7]">
+        <Skeleton className="size-full rounded-3xl" />
+        <Skeleton className="w-28 h-9 rounded-sm" />
+      </div>
+      <div className="flex flex-col gap-5">
+        <Skeleton className="w-60 h-12 rounded-md" />
+        <div className="flex gap-2">
+          {[...Array(6)].map((_, idx) => (
+            <Skeleton key={idx} className="w-12 h-7 rounded-sm" />
+          ))}
+        </div>
+        <Skeleton className="w-80 h-6 rounded-sm" />
+        <div className="flex gap-6">
+          <Skeleton className="size-36 rounded-lg" />
+          <Skeleton className="size-36 rounded-lg" />
+        </div>
+        <Skeleton className="w-60 h-10 rounded-full" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/guild/[guildid]/components/GuildMemberSection.tsx
+++ b/src/app/guild/[guildid]/components/GuildMemberSection.tsx
@@ -1,0 +1,21 @@
+import { useGuild } from '@/api/guild';
+import GuildUserCard from '@/components/guildUser/GuildUserCard';
+import { useQuery } from '@tanstack/react-query';
+
+export default function GuildMemberSection({ guildId }: { guildId: string }) {
+  const Guild = useGuild();
+
+  const { data: guildMemberData } = useQuery({
+    queryKey: ['GuildMember', guildId],
+    queryFn: () => Guild.GetGuildMembers(guildId),
+  });
+  console.log(guildMemberData);
+  return (
+    <div className="flex flex-col w-[67%] self-center gap-8">
+      <p className="text-4xl font-bold text-neutral-900">멤버</p>
+      <div className="grid grid-cols-3 gap-x-6 gap-y-6">
+        {guildMemberData && guildMemberData.map((member) => <GuildUserCard key={member.member_id} data={member} />)}
+      </div>
+    </div>
+  );
+}

--- a/src/app/guild/[guildid]/components/GuildMemberSection.tsx
+++ b/src/app/guild/[guildid]/components/GuildMemberSection.tsx
@@ -9,7 +9,6 @@ export default function GuildMemberSection({ guildId }: { guildId: string }) {
     queryKey: ['GuildMember', guildId],
     queryFn: () => Guild.GetGuildMembers(guildId),
   });
-  console.log(guildMemberData);
   return (
     <div className="flex flex-col w-[67%] self-center gap-8">
       <p className="text-4xl font-bold text-neutral-900">멤버</p>

--- a/src/app/guild/[guildid]/page.tsx
+++ b/src/app/guild/[guildid]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import PlayOnRollingBanner from '@/components/common/play-on-rolling-banner';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { Suspense, useEffect, useState } from 'react';
 import GuildInfoSection from './components/GuildInfoSection';
 import GuildInfoSectionSkeleton from './components/GuildInfoSectionSkeleton';
@@ -11,8 +11,17 @@ import GuildBoardNoticeSection from './components/GuildBoardNoticeSection';
 import { useGuildBoard } from '@/api/guildBoard';
 import { useQuery } from '@tanstack/react-query';
 import { useGuild } from '@/api/guild';
+import { useAuthStore } from '@/stores/authStore';
+import { PATH } from '@/constants/routes';
 
 export default function GuildDetails() {
+  const router = useRouter();
+  const { user } = useAuthStore();
+
+  if (user === undefined) {
+    router.push(PATH.login);
+  }
+
   const params = useParams();
   const guildId = params.guildid as string;
 

--- a/src/app/guild/[guildid]/page.tsx
+++ b/src/app/guild/[guildid]/page.tsx
@@ -1,98 +1,34 @@
 'use client';
 
-import { dummyGuild, dummyPost, dummyGuildUser } from '@/utils/dummyData';
-import Tag from '@/components/common/Tag';
-import { Button } from '@/components/ui/button';
-import { ChevronRight, ClipboardPenIcon } from 'lucide-react';
-import RetroButton from '@/components/common/RetroButton';
 import PlayOnRollingBanner from '@/components/common/play-on-rolling-banner';
-import CommunityPostImageLong from '@/components/community/post-image-long';
-import CommunityPostLong from '@/components/community/post-long';
-import CommunityPostImageShort from '@/components/community/post-image-short';
-import CommunityPostShort from '@/components/community/post-short';
-import GuildUserCard from '@/components/guildUser/GuildUserCard';
-import { guildUser } from '@/types/guild';
+import { useParams } from 'next/navigation';
+import { Suspense } from 'react';
+import GuildInfoSection from './components/GuildInfoSection';
+import GuildInfoSectionSkeleton from './components/GuildInfoSectionSkeleton';
+import GuildBoardLatestSection from './components/GuildBoardLatestSection';
+import GuildMemberSection from './components/GuildMemberSection';
+import GuildBoardNoticeSection from './components/GuildBoardNoticeSection';
 
 export default function GuildDetails() {
-  const allTags = [...dummyGuild.friendly, ...dummyGuild.gender, ...dummyGuild.play_style, ...dummyGuild.skill_level];
-  const dummyGuildUsers = new Array<guildUser>(9).fill(dummyGuildUser);
+  const params = useParams();
+  const guildId = params.guildid as string;
 
   return (
     <div className="flex flex-col mt-36 mb-36 gap-14">
-      <div className="flex gap-6 w-[67%] self-center">
-        <div className="flex flex-col gap-4 min-w-[628px] aspect-[16/7]">
-          <img src={dummyGuild.img_src} alt="" className="rounded-3xl" />
-          <Button variant="outline" className="w-fit px-4 py-2 text-neutral-500">
-            <ClipboardPenIcon />
-            <span>길드 관리</span>
-          </Button>
-        </div>
-        <div className="flex flex-col gap-5">
-          <p className="font-bold text-5xl text-neutral-900">{dummyGuild.guild_name}</p>
-          <div className="flex gap-2">
-            {allTags.map((e, ind) => (
-              <Tag style="retro" size="small" background="dark" className="" key={ind}>
-                {e}
-              </Tag>
-            ))}
-          </div>
-          <p className="text-sm text-neutral-900 font-medium line-clamp-4 text-ellipsis">{dummyGuild.description}</p>
-          <div className="flex gap-6">
-            <div className="w-36 bg-neutral-100 rounded-lg aspect-square flex flex-col items-center justify-center gap-2">
-              <p>CAPTAIN</p>
-              <img src={dummyGuild.owner.img_src} alt="" className="w-12 rounded-full " />
-              <p>{dummyGuild.owner.nickname}</p>
-            </div>
-            <div className="w-36 bg-neutral-100 rounded-lg aspect-square flex flex-col items-center justify-center">
-              <p>MEMBERS</p>
-              <p>
-                <span className="text-4xl font-extrabold">{`${dummyGuild.num_members}`}</span>
-                <span>{`/ ${60}`}</span>
-              </p>
-            </div>
-          </div>
-          <RetroButton type="purple" className="w-60">
-            길드 참여
-          </RetroButton>
-        </div>
-      </div>
+      <Suspense fallback={<GuildInfoSectionSkeleton />}>
+        <GuildInfoSection guildId={guildId} />
+      </Suspense>
+
       <PlayOnRollingBanner direction="right" duration={20} />
-      <div className="flex flex-col w-[67%] self-center">
-        <div className="flex w-full justify-between">
-          <p className="text-4xl font-bold text-neutral-900">공지</p>
-          <div className="flex items-center">
-            <p className="text-xl font-medium text-neutral-900">전체 보기</p>
-            <ChevronRight />
-          </div>
-        </div>
-        <div className="flex flex-col">
-          <CommunityPostImageLong data={dummyPost} className="h-44 border-b border-neutral-400" />
-          <CommunityPostLong data={dummyPost} className="h-44" />
-        </div>
-      </div>
-      <div className="flex flex-col w-[67%] self-center gap-8">
-        <p className="text-4xl font-bold text-neutral-900">멤버</p>
-        <div className="grid grid-cols-3 gap-x-6 gap-y-6">
-          {dummyGuildUsers.map((e, ind) => (
-            <GuildUserCard key={`${e.user.username}_${ind}`} data={e} />
-          ))}
-        </div>
-      </div>
-      <div className="flex flex-col gap-6 w-[67%] self-center">
-        <div className="flex w-full justify-between">
-          <p className="text-4xl font-bold text-neutral-900">길드 최신글</p>
-          <div className="flex items-center">
-            <p className="text-xl font-medium text-neutral-900">전체 보기</p>
-            <ChevronRight />
-          </div>
-        </div>
-        <div className="grid grid-cols-2 gap-x-6 gap-y-6">
-          <CommunityPostShort data={dummyPost} className="h-52" />
-          <CommunityPostImageShort data={dummyPost} className="h-52" />
-          <CommunityPostImageShort data={dummyPost} className="h-52" />
-          <CommunityPostShort data={dummyPost} className="h-52" />
-        </div>
-      </div>
+      <Suspense fallback={<div>데이터 불러오는 중...</div>}>
+        <GuildBoardNoticeSection guildId={guildId} />
+      </Suspense>
+      <Suspense fallback={<div>데이터 불러오는 중...</div>}>
+        <GuildMemberSection guildId={guildId} />
+      </Suspense>
+      <Suspense fallback={<div>데이터 불러오는 중...</div>}>
+        <GuildBoardLatestSection guildId={guildId} />
+      </Suspense>
     </div>
   );
 }

--- a/src/app/guild/[guildid]/page.tsx
+++ b/src/app/guild/[guildid]/page.tsx
@@ -2,32 +2,62 @@
 
 import PlayOnRollingBanner from '@/components/common/play-on-rolling-banner';
 import { useParams } from 'next/navigation';
-import { Suspense } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import GuildInfoSection from './components/GuildInfoSection';
 import GuildInfoSectionSkeleton from './components/GuildInfoSectionSkeleton';
 import GuildBoardLatestSection from './components/GuildBoardLatestSection';
 import GuildMemberSection from './components/GuildMemberSection';
 import GuildBoardNoticeSection from './components/GuildBoardNoticeSection';
+import { useGuildBoard } from '@/api/guildBoard';
+import { useQuery } from '@tanstack/react-query';
+import { useGuild } from '@/api/guild';
 
 export default function GuildDetails() {
   const params = useParams();
   const guildId = params.guildid as string;
 
+  const Guild = useGuild();
+  const GuildBoard = useGuildBoard();
+
+  const [isNotGuest, setIsNotGuest] = useState<boolean>(false);
+
+  const { data: guildData } = useQuery({
+    queryKey: ['GuildDetail', guildId],
+    queryFn: () => Guild.GetGuild(guildId),
+  });
+
+  const { data: guildBoardNotice } = useQuery({
+    queryKey: ['GuildBoardNotice', guildId],
+    queryFn: () => GuildBoard.GuildNoticesPost(Number(guildId)),
+    enabled: isNotGuest,
+  });
+
+  const { data: guildBoardLatest } = useQuery({
+    queryKey: ['GuildBoardLatest', guildId],
+    queryFn: () => GuildBoard.GuildLatestPost(Number(guildId)),
+    enabled: isNotGuest,
+  });
+
+  useEffect(() => {
+    if (guildData) {
+      setIsNotGuest(guildData.myRole !== 'GUEST');
+    }
+  }, [guildData]);
   return (
     <div className="flex flex-col mt-36 mb-36 gap-14">
       <Suspense fallback={<GuildInfoSectionSkeleton />}>
-        <GuildInfoSection guildId={guildId} />
+        {guildData && <GuildInfoSection guildData={guildData} />}
       </Suspense>
 
       <PlayOnRollingBanner direction="right" duration={20} />
       <Suspense fallback={<div>데이터 불러오는 중...</div>}>
-        <GuildBoardNoticeSection guildId={guildId} />
+        {guildBoardNotice && <GuildBoardNoticeSection guildId={guildId} guildBoardNotice={guildBoardNotice} />}
       </Suspense>
       <Suspense fallback={<div>데이터 불러오는 중...</div>}>
         <GuildMemberSection guildId={guildId} />
       </Suspense>
       <Suspense fallback={<div>데이터 불러오는 중...</div>}>
-        <GuildBoardLatestSection guildId={guildId} />
+        {guildBoardLatest && <GuildBoardLatestSection guildId={guildId} guildBoardLatest={guildBoardLatest} />}
       </Suspense>
     </div>
   );

--- a/src/app/guild/components/PopularGameCard.tsx
+++ b/src/app/guild/components/PopularGameCard.tsx
@@ -1,3 +1,4 @@
+import { PATH } from '@/constants/routes';
 import { cn } from '@/lib/utils';
 import { gameSimple } from '@/types/games';
 import { useRouter } from 'next/navigation';
@@ -15,7 +16,7 @@ export function PopularGameCard({ data, size }: PopularGameCardProps) {
         backgroundImage: `url(${data.img_src})`,
       }}
       className="w-full h-full bg-center bg-cover rounded-lg overflow-hidden cursor-pointer"
-      onClick={() => router.push('#')}
+      onClick={() => router.push(`${PATH.guild_list}?game=`)}
     >
       <div
         className={cn('w-full h-full bg-gradient-to-t from-black/50 to-black/0  flex items-end hover:from-black/30', {

--- a/src/app/guild/components/PopularGuildList.tsx
+++ b/src/app/guild/components/PopularGuildList.tsx
@@ -1,0 +1,14 @@
+import GuildHorizon from '@/components/guild/guild-horizon';
+import { guild } from '@/types/guild';
+
+export default function PopularGuildList(data: guild[]) {
+  return (
+    <>
+      <div className="grid grid-cols-3 gap-6">
+        {data.map((guild) => (
+          <GuildHorizon key={guild.guild_id} data={guild} />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/app/guild/components/PopularGuildList.tsx
+++ b/src/app/guild/components/PopularGuildList.tsx
@@ -1,7 +1,8 @@
 import GuildHorizon from '@/components/guild/guild-horizon';
 import { guild } from '@/types/guild';
 
-export default function PopularGuildList(data: guild[]) {
+export default function PopularGuildList({ data }: { data: guild[] | null }) {
+  if (!data) return <p>데이터가 없습니다.</p>;
   return (
     <>
       <div className="grid grid-cols-3 gap-6">

--- a/src/app/guild/components/PopularGuildListSkeleton.tsx
+++ b/src/app/guild/components/PopularGuildListSkeleton.tsx
@@ -1,0 +1,13 @@
+import { GuildHorizonSkeleton } from '@/components/guild/guild-horizon';
+
+export default function PopularGuildListSkeleton() {
+  return (
+    <>
+      <div className="grid grid-cols-3 gap-6">
+        {[...Array(3)].map((_, idx) => (
+          <GuildHorizonSkeleton key={idx} className="" />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/app/guild/page.tsx
+++ b/src/app/guild/page.tsx
@@ -5,45 +5,68 @@ import RetroButton from '@/components/common/RetroButton';
 import SearchBar from '@/components/common/SearchBar';
 import SectionBanner from '@/components/common/SectionBanner';
 import SectionTitle from '@/components/common/SectionTitle';
-import GuildHorizon from '@/components/guild/guild-horizon';
+import GuildHorizon, { GuildHorizonSkeleton } from '@/components/guild/guild-horizon';
 import PixelCharacter from '@/components/PixelCharacter/PixelCharacter';
 import { gameSimple } from '@/types/games';
 import { guild } from '@/types/guild';
 import { dummyGameSimple, dummyGuild } from '@/utils/dummyData';
-import { useState } from 'react';
 import PopularGameList from './components/PopularGameList';
 import SearchGuildWithGame from '@/components/common/search-guild-with-game';
+import { useRouter } from 'next/navigation';
+import { PATH } from '@/constants/routes';
+import { useGuild } from '@/api/guild';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
 
 const banner = [
   {
     title: 'Together!',
-    img_src: './img/hero/bg_guild_main.webp',
+    img_src: '/img/hero/bg_guild_main.webp',
   },
 ];
 
+// const placeholderImage = 'https://placehold.co/600x400?text=PlayOn+Guild';
+
 export default function Guild() {
-  const [query, setQuery] = useState<string>('');
-  const handleChange = (value: string) => {
-    setQuery(value);
-    console.log(query);
-  };
-  const handleSearch = () => {
-    alert('search click!');
+  const router = useRouter();
+  const Guild = useGuild();
+
+  // const [popularGuildList, setPopularGuild] = useState<guild[]>([]);
+
+  // const { data: popularGuildList, isLoading } = useQuery({
+  //   queryKey: ['PopularGuilds'],
+  //   queryFn: () => Guild.GetGuildPopular(),
+  // });
+
+  const handleSearch = (value: string) => {
+    router.push(`${PATH.guild_list}?keyword=${value}`);
   };
 
-  const dummyGuildList: guild[] = Array(3).fill(dummyGuild);
+  // const dummyGuildList: guild[] = Array(3).fill(dummyGuild);
   const dummyGameList: gameSimple[] = Array(4).fill(dummyGameSimple);
+
+  // const fetchPopularData = async () => {
+  //   const response = await Guild.GetGuildPopular();
+  //   if (response) {
+  //     setPopularGuild(response);
+  //   }
+  // };
+
+  // useEffect(() => {
+  //   fetchPopularData();
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, []);
   return (
     <div className="space-y-20 pb-20 pt-[68px]">
       <section className="w-full h-[400px]">
         <HeroTypingBanner data={banner} isStatic>
-          <SearchBar onChange={handleChange} onSearch={handleSearch} className="w-[640px]" />
+          <SearchBar onChange={() => {}} onSearch={handleSearch} className="w-[640px]" />
         </HeroTypingBanner>
       </section>
       <section className="wrapper space-y-20">
         <div className="flex justify-between items-end">
           <SectionTitle title="활동량 TOP 길드" subtitle="혼자서 게임하지 마세요!" icon_src="./img/icons/pixel_box.svg">
-            <RetroButton type="purple" className="w-[344px] h-[48px]">
+            <RetroButton type="purple" className="w-[344px] h-[48px]" callback={() => router.push(PATH.guild_list)}>
               더 많은 길드 찾기
             </RetroButton>
           </SectionTitle>
@@ -54,9 +77,11 @@ export default function Guild() {
           </div>
         </div>
         <div className="grid grid-cols-3 gap-6">
-          {dummyGuildList.map((guild) => (
-            <GuildHorizon key={guild.guild_name} data={guild} />
-          ))}
+          {/* {isLoading
+            ? [...Array(3)].map((_, index) => <GuildHorizonSkeleton className="" key={index} />)
+            : popularGuildList?.map((guild) => <GuildHorizon key={guild.guild_name} data={guild} />)} */}
+          {/* {popularGuildList.length > 0 &&
+            popularGuildList.map((guild) => <GuildHorizon key={guild.guild_name} data={guild} />)} */}
         </div>
       </section>
       <section>
@@ -77,7 +102,7 @@ export default function Guild() {
         <SectionBanner
           description="성향 및 목표가 같은 동료들과 함께하고 싶다면"
           highlight="지금 바로 나만의 길드를 만들어보세요!"
-          onClick={() => alert('click')}
+          onClick={() => router.push(PATH.guild_create)}
           className="bg-purple-400"
         >
           <img src="./img/3d_object/castle.webp" alt="icon" className="h-[180px]" />

--- a/src/app/guild/page.tsx
+++ b/src/app/guild/page.tsx
@@ -5,18 +5,18 @@ import RetroButton from '@/components/common/RetroButton';
 import SearchBar from '@/components/common/SearchBar';
 import SectionBanner from '@/components/common/SectionBanner';
 import SectionTitle from '@/components/common/SectionTitle';
-import GuildHorizon, { GuildHorizonSkeleton } from '@/components/guild/guild-horizon';
 import PixelCharacter from '@/components/PixelCharacter/PixelCharacter';
 import { gameSimple } from '@/types/games';
-import { guild } from '@/types/guild';
-import { dummyGameSimple, dummyGuild } from '@/utils/dummyData';
+import { dummyGameSimple } from '@/utils/dummyData';
 import PopularGameList from './components/PopularGameList';
 import SearchGuildWithGame from '@/components/common/search-guild-with-game';
 import { useRouter } from 'next/navigation';
 import { PATH } from '@/constants/routes';
 import { useGuild } from '@/api/guild';
-import { useQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Suspense } from 'react';
+import PopularGuildListSkeleton from './components/PopularGuildListSkeleton';
+import PopularGuildList from './components/PopularGuildList';
 
 const banner = [
   {
@@ -25,37 +25,21 @@ const banner = [
   },
 ];
 
-// const placeholderImage = 'https://placehold.co/600x400?text=PlayOn+Guild';
-
 export default function Guild() {
   const router = useRouter();
   const Guild = useGuild();
 
-  // const [popularGuildList, setPopularGuild] = useState<guild[]>([]);
-
-  // const { data: popularGuildList, isLoading } = useQuery({
-  //   queryKey: ['PopularGuilds'],
-  //   queryFn: () => Guild.GetGuildPopular(),
-  // });
+  const { data: popularGuildList } = useSuspenseQuery({
+    queryKey: ['PopularGuilds'],
+    queryFn: () => Guild.GetGuildPopular(),
+  });
 
   const handleSearch = (value: string) => {
     router.push(`${PATH.guild_list}?keyword=${value}`);
   };
 
-  // const dummyGuildList: guild[] = Array(3).fill(dummyGuild);
   const dummyGameList: gameSimple[] = Array(4).fill(dummyGameSimple);
 
-  // const fetchPopularData = async () => {
-  //   const response = await Guild.GetGuildPopular();
-  //   if (response) {
-  //     setPopularGuild(response);
-  //   }
-  // };
-
-  // useEffect(() => {
-  //   fetchPopularData();
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, []);
   return (
     <div className="space-y-20 pb-20 pt-[68px]">
       <section className="w-full h-[400px]">
@@ -76,13 +60,10 @@ export default function Guild() {
             <PixelCharacter char="warrior" motion="attack" />
           </div>
         </div>
-        <div className="grid grid-cols-3 gap-6">
-          {/* {isLoading
-            ? [...Array(3)].map((_, index) => <GuildHorizonSkeleton className="" key={index} />)
-            : popularGuildList?.map((guild) => <GuildHorizon key={guild.guild_name} data={guild} />)} */}
-          {/* {popularGuildList.length > 0 &&
-            popularGuildList.map((guild) => <GuildHorizon key={guild.guild_name} data={guild} />)} */}
-        </div>
+        <div className="grid grid-cols-3 gap-6"></div>
+        <Suspense fallback={<PopularGuildListSkeleton />}>
+          <PopularGuildList data={popularGuildList} />
+        </Suspense>
       </section>
       <section>
         <PlayOnRollingBanner duration={20} direction="left" />

--- a/src/components/common/SectionBanner.tsx
+++ b/src/components/common/SectionBanner.tsx
@@ -19,7 +19,10 @@ export default function SectionBanner({
 }: SectionBannerProps) {
   return (
     <div
-      className={cn('w-full h-60 bg-purple-500 rounded-xl px-16 py-12 flex items-center justify-between', className)}
+      className={cn(
+        'w-full h-60 bg-purple-500 rounded-xl px-16 py-12 flex items-center justify-between cursor-pointer',
+        className
+      )}
       onClick={onClick}
     >
       <div className={`flex flex-col h-full ${introText ? 'justify-between' : 'justify-center'}`}>

--- a/src/components/community/post-image-long.tsx
+++ b/src/components/community/post-image-long.tsx
@@ -1,12 +1,15 @@
-import { post } from '@/types/community';
+import { postSimple } from '@/types/community';
 import { ThumbsUpIcon, SubtitlesIcon } from 'lucide-react';
 import AvatarName, { AvatarNameSkeleton } from './common/avatar-name';
 import { Skeleton } from '../ui/skeleton';
 import Tag from '@/components/common/Tag';
+import { PATH } from '@/constants/routes';
+import { useRouter } from 'next/navigation';
 
 type CommunityPostImageLongProps = {
-  data: post;
+  data: postSimple;
   className: string;
+  onClick?: () => void;
 };
 
 export function CommunityPostImageLongSkeleton(props: { className: string }) {
@@ -30,11 +33,15 @@ export function CommunityPostImageLongSkeleton(props: { className: string }) {
 }
 
 export default function CommunityPostImageLong(props: CommunityPostImageLongProps) {
+  const router = useRouter();
   return (
-    <div className={`flex gap-5 py-7 ` + props.className}>
+    <div
+      className={`flex gap-5 py-7 cursor-pointer ` + props.className}
+      onClick={props.onClick ? props.onClick : () => router.push(PATH.community_detail(String(props.data.postId)))}
+    >
       <img src={props.data.img_src} alt="Loading" className="object-cover h-full aspect-[1/1] rounded-xl" />
-      <div className="flex flex-col justify-between">
-        <AvatarName userName={props.data.user.nickname} avatar={props.data.user.img_src} />
+      <div className="flex flex-col justify-between w-full">
+        <AvatarName userName={props.data.author_nickname} avatar={props.data.author_img} />
         <p className="text-xl font-suit font-bold">{props.data.title}</p>
         <p className="text-base font-suit line-clamp-2 text-justify ">{props.data.content}</p>
         <div className="flex justify-between">
@@ -50,7 +57,7 @@ export default function CommunityPostImageLong(props: CommunityPostImageLongProp
             </div>
             <div className="flex items-center gap-1">
               <SubtitlesIcon className="text-neutral-400 w-4 h-4 stroke" />
-              <p className="font-suit text-sm font-medium text-neutral-400">{props.data.comments.length}</p>
+              <p className="font-suit text-sm font-medium text-neutral-400">{props.data.comments_num}</p>
             </div>
           </div>
         </div>

--- a/src/components/community/post-image-short.tsx
+++ b/src/components/community/post-image-short.tsx
@@ -1,12 +1,13 @@
-import { post } from '@/types/community';
-
+import { postSimple } from '@/types/community';
 import { ThumbsUpIcon, SubtitlesIcon } from 'lucide-react';
 import AvatarName, { AvatarNameSkeleton } from './common/avatar-name';
 import { Skeleton } from '../ui/skeleton';
 import Tag from '@/components/common/Tag';
+import { PATH } from '@/constants/routes';
+import { useRouter } from 'next/navigation';
 
 type CommunityPostImageShortProps = {
-  data: post;
+  data: postSimple;
   className: string;
 };
 
@@ -31,11 +32,15 @@ export function CommunityPostImageShortSkeleton(props: { className: string }) {
 }
 
 export default function CommunityPostImageShort(props: CommunityPostImageShortProps) {
+  const router = useRouter();
   return (
-    <div className={`flex gap-5 p-5 rounded-xl border border-neutral-300 ` + props.className}>
+    <div
+      className={`flex gap-5 p-5 rounded-xl border border-neutral-300 ` + props.className}
+      onClick={() => router.push(PATH.community_detail(String(props.data.postId)))}
+    >
       <img src={props.data.img_src} alt="Loading" className="object-cover h-full aspect-[1/1] rounded-xl" />
-      <div className="flex flex-col justify-between">
-        <AvatarName userName={props.data.user.nickname} avatar={props.data.user.img_src} />
+      <div className="flex flex-col justify-between w-full">
+        <AvatarName userName={props.data.author_nickname} avatar={props.data.author_img} />
         <p className="text-xl font-suit font-bold">{props.data.title}</p>
         <p className="text-base font-suit line-clamp-2 text-justify ">{props.data.content}</p>
         <div className="flex justify-between">
@@ -51,7 +56,7 @@ export default function CommunityPostImageShort(props: CommunityPostImageShortPr
             </div>
             <div className="flex items-center gap-1">
               <SubtitlesIcon className="text-neutral-400 w-4 h-4 stroke" />
-              <p className="font-suit text-sm font-medium text-neutral-400">{props.data.comments.length}</p>
+              <p className="font-suit text-sm font-medium text-neutral-400">{props.data.comments_num}</p>
             </div>
           </div>
         </div>

--- a/src/components/community/post-long.tsx
+++ b/src/components/community/post-long.tsx
@@ -1,13 +1,16 @@
-import { post } from '@/types/community';
+import { postSimple } from '@/types/community';
 
 import AvatarName, { AvatarNameSkeleton } from './common/avatar-name';
 import { SubtitlesIcon, ThumbsUpIcon } from 'lucide-react';
 import { Skeleton } from '../ui/skeleton';
 import Tag from '@/components/common/Tag';
+import { useRouter } from 'next/navigation';
+import { PATH } from '@/constants/routes';
 
 type CommunityPostImageLongProps = {
-  data: post;
+  data: postSimple;
   className: string;
+  onClick?: () => void;
 };
 
 export function CommunityPostLongSkeleton(props: { className: string }) {
@@ -28,14 +31,18 @@ export function CommunityPostLongSkeleton(props: { className: string }) {
 }
 
 export default function CommunityPostLong(props: CommunityPostImageLongProps) {
+  const router = useRouter();
   return (
-    <div className={`flex flex-col py-7 justify-between ` + props.className}>
-      <AvatarName userName={props.data.user.nickname} avatar={props.data.user.img_src} />
+    <div
+      className={`flex flex-col py-7 justify-between cursor-pointer ` + props.className}
+      onClick={props.onClick ? props.onClick : () => router.push(PATH.community_detail(String(props.data.postId)))}
+    >
+      <AvatarName userName={props.data.author_nickname} avatar={props.data.author_img} />
       <div>
         <p className="text-xl font-suit font-bold">{props.data.title}</p>
         <p className="text-base font-suit line-clamp-2 text-justify ">{props.data.content}</p>
       </div>
-      <div className="flex justify-between">
+      <div className="flex justify-between w-full">
         <div className="flex gap-1">
           <Tag background="medium" style="default" className="font-bold">
             {props.data.tag}
@@ -48,7 +55,7 @@ export default function CommunityPostLong(props: CommunityPostImageLongProps) {
           </div>
           <div className="flex items-center gap-1">
             <SubtitlesIcon className="text-neutral-400 w-4 h-4 stroke" />
-            <p className="font-suit text-sm font-medium text-neutral-400">{props.data.comments.length}</p>
+            <p className="font-suit text-sm font-medium text-neutral-400">{props.data.comments_num}</p>
           </div>
         </div>
       </div>

--- a/src/components/community/post-short.tsx
+++ b/src/components/community/post-short.tsx
@@ -1,12 +1,14 @@
-import { post } from '@/types/community';
+import { post, postSimple } from '@/types/community';
 
 import AvatarName, { AvatarNameSkeleton } from './common/avatar-name';
 import { SubtitlesIcon, ThumbsUpIcon } from 'lucide-react';
 import { Skeleton } from '../ui/skeleton';
 import Tag from '@/components/common/Tag';
+import { useRouter } from 'next/navigation';
+import { PATH } from '@/constants/routes';
 
 type CommunityPostImageShortProps = {
-  data: post;
+  data: postSimple;
   className: string;
 };
 
@@ -28,9 +30,15 @@ export function CommunityPostShortSkeleton(props: { className: string }) {
 }
 
 export default function CommunityPostShort(props: CommunityPostImageShortProps) {
+  const router = useRouter();
   return (
-    <div className={`border border-neutral-300 rounded-xl p-5 flex flex-col justify-between ` + props.className}>
-      <AvatarName userName={props.data.user.nickname} avatar={props.data.user.img_src} />
+    <div
+      className={`border border-neutral-300 rounded-xl p-5 flex flex-col justify-between ` + props.className}
+      onClick={() => {
+        router.push(PATH.community_detail(String(props.data.postId)));
+      }}
+    >
+      <AvatarName userName={props.data.author_nickname} avatar={props.data.author_img} />
       <div>
         <p className="text-xl font-suit font-bold">{props.data.title}</p>
         <p className="text-base font-suit line-clamp-2 text-justify ">{props.data.content}</p>
@@ -48,7 +56,7 @@ export default function CommunityPostShort(props: CommunityPostImageShortProps) 
           </div>
           <div className="flex items-center gap-1">
             <SubtitlesIcon className="text-neutral-400 w-4 h-4 stroke" />
-            <p className="font-suit text-sm font-medium text-neutral-400">{props.data.comments.length}</p>
+            <p className="font-suit text-sm font-medium text-neutral-400">{props.data.comments_num}</p>
           </div>
         </div>
       </div>

--- a/src/components/guild/guild-horizon.tsx
+++ b/src/components/guild/guild-horizon.tsx
@@ -20,7 +20,7 @@ export function GuildHorizonSkeleton(props: { className: string }) {
   );
 }
 
-const defaultImg = 'https://placehold.co/600x400/9884F0/3F1AC4?text=PlayOn+Guild';
+const defaultImg = '/img/hero/bg_community_main.webp';
 
 export default function GuildHorizon(props: GuildHorizonProps) {
   const tagsArr = [

--- a/src/components/guild/guild-horizon.tsx
+++ b/src/components/guild/guild-horizon.tsx
@@ -20,6 +20,8 @@ export function GuildHorizonSkeleton(props: { className: string }) {
   );
 }
 
+const defaultImg = 'https://placehold.co/600x400/9884F0/3F1AC4?text=PlayOn+Guild';
+
 export default function GuildHorizon(props: GuildHorizonProps) {
   const tagsArr = [
     ...props.data.play_style,
@@ -29,7 +31,7 @@ export default function GuildHorizon(props: GuildHorizonProps) {
   ].slice(0, 3);
   return (
     <div className={`bg-white rounded-2xl overflow-hidden border border-neutral-200 ` + props.className}>
-      <img src={props.data.img_src} alt="loading" className="w-full object-cover aspect-[16/9]" />
+      <img src={props.data.img_src || defaultImg} alt="loading" className="w-full object-cover aspect-[16/9]" />
       <div className="p-5 gap-1">
         <p className="font-suit text-2xl font-bold pb-2">{props.data.guild_name}</p>
         <p className="font-suit text-base font-medium text-nowrap text-ellipsis overflow-hidden">

--- a/src/components/guildUser/GuildUserCard.tsx
+++ b/src/components/guildUser/GuildUserCard.tsx
@@ -1,18 +1,22 @@
 import { Avatar, AvatarImage } from '@/components/ui/avatar';
-import { guildUser } from '@/types/guild';
+import { PATH } from '@/constants/routes';
+import { guildUserSimple } from '@/types/guild';
 import { Crown, Star } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 
 interface guildUserCardProps2 {
-  data: guildUser;
+  data: guildUserSimple;
 }
 
 export default function GuildUserCard(props: guildUserCardProps2) {
   const { data } = props;
   let badge;
-  const joindDate = new Date(data.joined_at).toLocaleDateString('ko-KR');
+  const joinedDate = new Date(data.joined_at).toLocaleDateString('ko-KR');
 
-  switch (data.guild_role) {
-    case 'leader':
+  const router = useRouter();
+
+  switch (data.role) {
+    case 'LEADER':
       badge = (
         <div className="bg-amber-300 rounded-full w-5 h-5 absolute bottom-0 right-0">
           <Crown className="w-5 h-5 p-1" color="#ffffff" />
@@ -20,33 +24,36 @@ export default function GuildUserCard(props: guildUserCardProps2) {
       );
       break;
 
-    case 'manager':
+    case 'MANAGER':
       badge = (
         <div className="bg-red-300 rounded-full w-5 h-5 absolute bottom-0 right-0">
           <Star className="w-5 h-5 p-1" color="#ffffff" />
         </div>
       );
       break;
-    case 'user':
+    case 'MEMBER':
       badge = <div></div>;
   }
 
   return (
     <>
-      <div className="box-content rounded-lg border border-neutral-300 px-6 py-8">
+      <div
+        className="box-content rounded-lg border border-neutral-300 px-6 py-8 cursor-pointer"
+        onClick={() => {
+          router.push(PATH.user_page(String(data.member_id)));
+        }}
+      >
         <div className="flex gap-5">
           <div className="w-16 h-16 aspect-square relative ">
             <Avatar className="bg-neutral-400 w-16 h-16">
-              <AvatarImage src={data.user.img_src} />
+              <AvatarImage src={data.img_src} className="" />
             </Avatar>
             {badge}
           </div>
           <div>
-            {data.user.user_title && (
-              <p className="font-suit text-sm font-normal text-neutral-500">{data.user.user_title}</p>
-            )}
-            <p className="font-suit text-xl font-medium">{data.user.nickname}</p>
-            {data.joined_at && <p className="font-suit text-sm font-normal text-neutral-500">가입일 : {joindDate}</p>}
+            {data.title && <p className="font-suit text-sm font-normal text-neutral-500">{data.title}</p>}
+            <p className="font-suit text-xl font-medium">{data.username}</p>
+            {data.joined_at && <p className="font-suit text-sm font-normal text-neutral-500">가입일 : {joinedDate}</p>}
           </div>
         </div>
       </div>

--- a/src/constants/endpoints/guild.ts
+++ b/src/constants/endpoints/guild.ts
@@ -1,12 +1,12 @@
 export const GUILD_ENDPOINTS = Object.freeze({
-  detail: (guildId: number) => `/guilds/${guildId}`,
-  modify: (guildId: number) => `/guilds/${guildId}`,
-  delete: (guildId: number) => `/guilds/${guildId}`,
+  detail: (guildId: string) => `/guilds/${guildId}`,
+  modify: (guildId: string) => `/guilds/${guildId}`,
+  delete: (guildId: string) => `/guilds/${guildId}`,
   create: '/guilds',
-  upload_image: (guildId: number) => `/guilds/${guildId}/img`,
+  upload_image: (guildId: string) => `/guilds/${guildId}/img`,
   list: '/guilds/list',
-  detail_member: (guildId: number) => `/guilds/${guildId}/members/page`,
-  admin: (guildId: number) => `/guilds/${guildId}/admin`,
+  detail_member: (guildId: string) => `/guilds/${guildId}/members/page`,
+  admin: (guildId: string) => `/guilds/${guildId}/admin`,
   recommend: '/guilds/recommend',
   popular: '/guilds/popular',
 });

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -27,3 +27,15 @@ export interface comment {
   content: string;
   createdAt: Date;
 }
+
+export interface postSimple {
+  postId: number;
+  author_nickname: string;
+  author_img: string;
+  title: string;
+  content: string;
+  img_src: string;
+  num_likes: number;
+  comments_num: number;
+  tag: string;
+}

--- a/src/types/guild.ts
+++ b/src/types/guild.ts
@@ -3,6 +3,7 @@ import { userDetail, userSimple } from './user';
 import { gameSimple } from './games';
 
 export interface guild {
+  guild_id: number;
   guild_name: string; // 길드명
   description: string; // 소개글
   main_game?: gameSimple; // 선택 게임

--- a/src/types/guild.ts
+++ b/src/types/guild.ts
@@ -25,3 +25,12 @@ export interface guildUser {
   joined_at: Date;
   num_guild_posts: number;
 }
+
+export interface guildUserSimple {
+  username: string;
+  title: string | null;
+  role: string;
+  img_src: string;
+  member_id: number;
+  joined_at: Date;
+}

--- a/src/types/guild.ts
+++ b/src/types/guild.ts
@@ -9,6 +9,7 @@ export interface guild {
   main_game?: gameSimple; // 선택 게임
   img_src: string; // 대표이미지
   num_members: number; // 길드 인원 수
+  max_members: number;
   owner: userSimple;
   created_at: Date;
   myRole: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

#205 

## 📝작업 내용

1. 길드 메인 페이지 
   - 버튼 라우팅
   - 상단 활동량 TOP 길드 연동

2. 길드 상세 페이지
   - 길드 멤버일 경우 모든 정보가 다 보이고, 길드 멤버가 아닐 경우, 공지글과 최신글은 안보입니다.
   - 로그인이 안되어 있을 경우에는 로그인 페이지로 이동합니다. (조금 이상)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
