### PR TITLE
feat: 길드 리스트 페이지 연동 및 dummy_profile 적용

### DIFF
--- a/src/api/guild.ts
+++ b/src/api/guild.ts
@@ -4,7 +4,6 @@ import { useAxios } from '@/hooks/useAxios';
 import { guild } from '@/types/guild';
 import {
   GuildDetailResponse,
-  Sort,
   GuildMainResponse,
   GuildUpdateRequest,
   GuildCreateRequest,
@@ -70,7 +69,7 @@ export const useGuild = () => {
     return data;
   }
 
-  async function GetGuildList(request: GuildLIstRequest, page?: number, pageSize?: number, sort?: Sort) {
+  async function GetGuildList(request: GuildLIstRequest, page?: number, pageSize?: number, sort?: string) {
     const response = await axios.Post(
       GUILD.list,
       request,
@@ -83,9 +82,9 @@ export const useGuild = () => {
       },
       true
     );
-    console.log(response);
+    // console.log(response);
     const data = response?.data.data.items;
-    console.log(data);
+    // console.log(data);
     if (data && data.length > 0) {
       const guildList: guild[] = data.map((item: GuildSimple) => {
         const tags = categorizeTags(item.tags);
@@ -213,7 +212,7 @@ export const useGuild = () => {
           username: member.username,
           title: member.title,
           role: member.role,
-          img_src: member.profileImg || 'https://placehold.co/200',
+          img_src: member.profileImg || '/img/dummy_profile.jpg',
           member_id: member.memberId,
           joined_at: new Date(member.joinedAt),
         };

--- a/src/app/guild/[guildid]/components/GuildInfoSection.tsx
+++ b/src/app/guild/[guildid]/components/GuildInfoSection.tsx
@@ -2,7 +2,6 @@
 
 import RetroButton from '@/components/common/RetroButton';
 import Tag from '@/components/common/Tag';
-import GhostSVG from '@/components/svg/ghost_fill';
 import { Button } from '@/components/ui/button';
 import { PATH } from '@/constants/routes';
 import { guild } from '@/types/guild';
@@ -47,13 +46,11 @@ export default function GuildInfoSection({ guildData }: { guildData: guild }) {
             <div className="flex gap-6">
               <div className="w-36 py-5 bg-neutral-100 rounded-lg aspect-square flex flex-col items-center justify-start gap-2">
                 <p className="font-semibold">CAPTAIN</p>
-                {guildData.owner.img_src ? (
-                  <img src={guildData.owner.img_src} alt="" className="w-12 rounded-full object-cover" />
-                ) : (
-                  <div className="bg-purple-300 size-12 rounded-full flex justify-center items-center">
-                    <GhostSVG width={24} fill="#FFFFFF" stroke="" />
-                  </div>
-                )}
+                <img
+                  src={guildData.owner.img_src || '/img/dummy_profile.jpg'}
+                  alt=""
+                  className="w-12 rounded-full object-cover"
+                />
                 <p>{guildData.owner.nickname}</p>
               </div>
               <div className="w-36 py-5 bg-neutral-100 rounded-lg aspect-square flex flex-col items-center justify-start gap-5">

--- a/src/components/guild/guild-horizon.tsx
+++ b/src/components/guild/guild-horizon.tsx
@@ -1,6 +1,8 @@
 import { guild } from '@/types/guild';
 import { UsersIcon } from 'lucide-react';
 import { Skeleton } from '../ui/skeleton';
+import { useRouter } from 'next/navigation';
+import { PATH } from '@/constants/routes';
 
 type GuildHorizonProps = {
   data: guild;
@@ -29,15 +31,19 @@ export default function GuildHorizon(props: GuildHorizonProps) {
     ...props.data.gender,
     ...props.data.friendly,
   ].slice(0, 3);
+  const router = useRouter();
   return (
-    <div className={`bg-white rounded-2xl overflow-hidden border border-neutral-200 ` + props.className}>
+    <div
+      className={`bg-white rounded-2xl overflow-hidden border border-neutral-200 cursor-pointer ` + props.className}
+      onClick={() => router.push(PATH.guild_detail(String(props.data.guild_id)))}
+    >
       <img src={props.data.img_src || defaultImg} alt="loading" className="w-full object-cover aspect-[16/9]" />
       <div className="p-5 gap-1">
         <p className="font-suit text-2xl font-bold pb-2">{props.data.guild_name}</p>
         <p className="font-suit text-base font-medium text-nowrap text-ellipsis overflow-hidden">
           {props.data.description}
         </p>
-        <div className="font-suit text-sm font-medium flex gap-4">
+        <div className="font-suit text-sm font-medium flex gap-4 justify-between">
           <div className="flex gap-1">
             {tagsArr.map((e, ind) => (
               <p key={ind}>#{e}</p>


### PR DESCRIPTION
## #️⃣연관된 이슈

#220 

## 📝작업 내용

- 게임 검색 기능 제외하고, 길드 리스트 페이지 연동 했습니다.
- 길드 상세 페이지에 dummy_profile 적용해두었습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
