### PR TITLE
255 feat 길드 페이지 수정

### DIFF
--- a/src/api/guild-member.ts
+++ b/src/api/guild-member.ts
@@ -85,11 +85,10 @@ export const useGuildsMembers = () => {
   }
 
   // 길드 탈퇴
-  async function LeaveMembers(guildId: string, newLeaderId: string) {
+  async function LeaveMembers(guildId: string, newLeaderId?: string) {
     const response = await axios.Delete(
       guildMember.leave(guildId),
       {
-        params: { guildId: guildId },
         data: { newLeaderId: newLeaderId },
       },
       true

--- a/src/api/guild.ts
+++ b/src/api/guild.ts
@@ -210,6 +210,7 @@ export const useGuild = () => {
       const guildMemberList = data.map((member) => {
         return {
           username: member.username,
+          nickname: member.nickname,
           title: member.title,
           role: member.role,
           img_src: member.profileImg || '/img/dummy_profile.jpg',
@@ -217,6 +218,7 @@ export const useGuild = () => {
           joined_at: new Date(member.joinedAt),
         };
       });
+      console.log(guildMemberList);
       return guildMemberList;
     }
     return false;

--- a/src/api/guildBoard.ts
+++ b/src/api/guildBoard.ts
@@ -1,6 +1,6 @@
 import { GUILD_BOARD_ENDPOINTS } from '@/constants/endpoints/guild-board';
 import { useAxios } from '@/hooks/useAxios';
-import { postSimple, comment, post } from '@/types/community';
+import { postSimple, post } from '@/types/community';
 import { uploadToS3 } from '@/utils/uploadToS3';
 // import { guildCommunityTags } from '@/types/Tags/communityTags';
 
@@ -35,6 +35,7 @@ export const useGuildBoard = () => {
     guild: guild;
     createdAt: string;
     isAuthor: boolean;
+    isLiked: boolean;
   };
   type noticesPost = {
     id: number;
@@ -61,7 +62,7 @@ export const useGuildBoard = () => {
     if (response && response.msg === 'OK') {
       const postData = response.data;
       // console.log('postData', postData);
-      const postDetail: post & { isAuthor: boolean } = {
+      const postDetail: post & { isAuthor: boolean; isLiked: boolean } = {
         user: {
           username: postData.authorNickname,
           nickname: postData.authorNickname,
@@ -92,6 +93,7 @@ export const useGuildBoard = () => {
         channel: '길드',
         tag: postData.tag,
         isAuthor: postData.isAuthor,
+        isLiked: postData.isLiked,
       };
       // console.log('postDetail', postDetail);
       return postDetail;

--- a/src/app/guild/[guildid]/admin/page.tsx
+++ b/src/app/guild/[guildid]/admin/page.tsx
@@ -382,7 +382,7 @@ export default function GuildAdmin() {
               return (
                 <GuildUser
                   key={`${member.memberId}-${index}`}
-                  membetId={member.memberId}
+                  memberId={member.memberId}
                   data={member.data}
                   index={index}
                   total={members.length}

--- a/src/app/guild/[guildid]/community/[postid]/page.tsx
+++ b/src/app/guild/[guildid]/community/[postid]/page.tsx
@@ -18,7 +18,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import styles from './guildCommunityDetail.module.css';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useToast } from '@/hooks/use-toast';
 
 const commentSchema = z.object({
@@ -43,6 +43,7 @@ export default function GuildCommunityDetail() {
   const Toast = useToast();
   const guildId = param.guildid as string;
   const boardId = param.postid as string;
+  const [isLiked, setIsLiked] = useState(false);
 
   const { data: guildData } = useQuery({
     queryKey: ['GuildDetail', guildId],
@@ -53,12 +54,14 @@ export default function GuildCommunityDetail() {
     queryKey: ['PostDetailData', guildId, boardId],
     queryFn: () => guildBoard.GuildPostDetail(parseInt(guildId), parseInt(boardId)),
   });
+  // console.log('postData', postData);
 
   const handleClickLike = useCallback(async () => {
     const response = await guildBoard.GuildPostLike(parseInt(guildId), parseInt(boardId));
     console.log(response);
     queryClient.refetchQueries({ queryKey: ['PostDetailData', guildId, boardId], exact: true });
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [boardId, guildId]);
 
   const deletePost = useCallback(async () => {
     const response = await guildBoard.GuildPostDelete(parseInt(guildId), parseInt(boardId));
@@ -69,13 +72,19 @@ export default function GuildCommunityDetail() {
       });
     }
     router.push(PATH.guild_community(guildId));
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [boardId, guildId]);
 
   async function onSubmit(data: CommentType) {
     const response = await guildBoard.GuildPostCommentCreate(Number(guildId), Number(boardId), data.comment);
     if (response) form.setValue('comment', '');
     queryClient.refetchQueries({ queryKey: ['PostDetailData', guildId, boardId], exact: true });
   }
+  useEffect(() => {
+    if (postData) {
+      setIsLiked(postData.isLiked);
+    }
+  }, [postData]);
 
   return (
     <div className="wrapper relative mb-12 mt-28">
@@ -145,6 +154,7 @@ export default function GuildCommunityDetail() {
               <Toggle
                 variant="outline"
                 size="lg"
+                pressed={isLiked}
                 className="rounded-full text-neutral-400 border-neutral-300 text-xl min-w-[60px] hover:text-purple-500 hover:bg-purple-50 focus-visible:text-purple-500 data-[state=on]:bg-purple-50 data-[state=on]:text-purple-500"
                 onClick={handleClickLike}
               >

--- a/src/app/guild/[guildid]/community/create/page.tsx
+++ b/src/app/guild/[guildid]/community/create/page.tsx
@@ -9,7 +9,6 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { PATH } from '@/constants/routes';
 import { useToast } from '@/hooks/use-toast';
-import { guildCommunityTags } from '@/types/Tags/communityTags';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronDown } from 'lucide-react';
@@ -43,6 +42,9 @@ export default function GuildCommunityCreate() {
     queryKey: ['guildDetail', params.guildId],
     queryFn: () => guild.GetGuild(guildId),
   });
+  console.log(guildData);
+  const guildCommunityTagsByRole =
+    guildData && guildData.myRole === 'MEMBER' ? ['자유', '게임관련'] : ['공지', '자유', '게임관련'];
 
   const form = useForm<createCommunityFormType>({
     defaultValues: {
@@ -117,7 +119,7 @@ export default function GuildCommunityCreate() {
                       </FormControl>
                       <SelectContent>
                         <SelectGroup>
-                          {guildCommunityTags.map((tag) => (
+                          {guildCommunityTagsByRole.map((tag) => (
                             <SelectItem key={tag} value={tag} className="text-xl text-neutral-900">
                               {tag}
                             </SelectItem>

--- a/src/app/guild/[guildid]/community/page.tsx
+++ b/src/app/guild/[guildid]/community/page.tsx
@@ -62,7 +62,7 @@ export default function GuildCommunity() {
       // console.log('data:', data);
 
       const posts = await guildBoard.GuildPostList(parseInt(guildId), data);
-      console.log(posts);
+      // console.log(posts);
       if (posts) {
         setPostList(posts.content);
         setTotalItems(posts.totalElements);
@@ -82,9 +82,9 @@ export default function GuildCommunity() {
       </section>
       <section className="flex gap-12">
         {guildData && (
-          <div className="w-1/3 relative -top-16">
+          <button className="w-1/3 relative -top-16">
             <WeNeedYou guildData={guildData} className="sticky top-10 bg-white" />
-          </div>
+          </button>
         )}
         {totalItems > 0 && (
           <section className="w-full space-y-10 pt-8">

--- a/src/app/guild/[guildid]/components/GuildInfoSection.tsx
+++ b/src/app/guild/[guildid]/components/GuildInfoSection.tsx
@@ -101,11 +101,13 @@ export default function GuildInfoSection({ guildId }: { guildId: string }) {
           <div className="flex flex-col gap-5">
             <p className="font-bold text-5xl text-neutral-900">{guildData.guild_name}</p>
             <div className="flex gap-2">
-              {getTagList(guildData).map((e, ind) => (
-                <Tag style="retro" size="small" background="dark" className="" key={ind}>
-                  {e}
-                </Tag>
-              ))}
+              {getTagList(guildData)
+                .slice(0, 8)
+                .map((e, ind) => (
+                  <Tag style="retro" size="small" background="dark" className="" key={ind}>
+                    {e}
+                  </Tag>
+                ))}
             </div>
             <p className="text-sm text-neutral-900 font-medium line-clamp-4 text-ellipsis">{guildData.description}</p>
             <div className="flex gap-6">

--- a/src/app/guild/[guildid]/components/GuildInfoSection.tsx
+++ b/src/app/guild/[guildid]/components/GuildInfoSection.tsx
@@ -13,11 +13,13 @@ import { ClipboardPenIcon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 import styles from './guildInfo.module.css';
+import { useGuildsMembers } from '@/api/guild-member';
 
 export default function GuildInfoSection({ guildId }: { guildId: string }) {
   const router = useRouter();
   const Guild = useGuild();
   const guildJoin = useGuildJoin();
+  const guildMembers = useGuildsMembers();
   const Toast = useToast();
   const getTagList = (data: guild) => {
     return [...data.friendly, ...data.gender, ...data.play_style, ...data.skill_level];
@@ -45,10 +47,25 @@ export default function GuildInfoSection({ guildId }: { guildId: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const leaveGuild = useCallback(async () => {
+    if (guildData && guildData.myRole === 'LEADER') {
+      console.log('리더는 탈퇴 못해요');
+      return;
+    }
+    const response = await guildMembers.LeaveMembers(guildId);
+    console.log(response);
+    Toast.toast({
+      title: '길드를 탈퇴했습니다.',
+      variant: 'primary',
+    });
+    queryClient.refetchQueries({ queryKey: ['GuildDetail', guildId], exact: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const GuildActionButton = () => {
     if (guildData === false) return;
     if (guildData.max_members > guildData.num_members) {
-      if (guildData?.myRole === 'GUEST') {
+      if (guildData.myRole === 'GUEST') {
         return (
           <RetroButton type="purple" className="w-60" callback={requestGuildJoin}>
             길드 참여
@@ -64,17 +81,25 @@ export default function GuildInfoSection({ guildId }: { guildId: string }) {
         );
       } else {
         return (
-          <RetroButton type="purple" className="w-60" callback={() => {}}>
+          <RetroButton type="purple" className="w-60" callback={leaveGuild}>
             길드 탈퇴
           </RetroButton>
         );
       }
     } else {
-      return (
-        <RetroButton type="grey" className="w-60">
-          인원 마감
-        </RetroButton>
-      );
+      if (guildData.myRole === 'GUEST' || guildData.myRole === 'APPLICANT') {
+        return (
+          <RetroButton type="grey" className="w-60">
+            인원 마감
+          </RetroButton>
+        );
+      } else {
+        return (
+          <RetroButton type="purple" className="w-60" callback={leaveGuild}>
+            길드 탈퇴
+          </RetroButton>
+        );
+      }
     }
   };
 

--- a/src/app/guild/[guildid]/components/GuildInfoSection.tsx
+++ b/src/app/guild/[guildid]/components/GuildInfoSection.tsx
@@ -116,7 +116,7 @@ export default function GuildInfoSection({ guildId }: { guildId: string }) {
                 <img
                   src={guildData.owner.img_src || '/img/dummy_profile.jpg'}
                   alt=""
-                  className="w-12 rounded-full object-cover"
+                  className="size-12 rounded-full object-cover"
                 />
                 <p>{guildData.owner.nickname}</p>
               </div>

--- a/src/app/guild/[guildid]/components/GuildMemberSection.tsx
+++ b/src/app/guild/[guildid]/components/GuildMemberSection.tsx
@@ -9,6 +9,7 @@ export default function GuildMemberSection({ guildId }: { guildId: string }) {
     queryKey: ['GuildMember', guildId],
     queryFn: () => Guild.GetGuildMembers(guildId),
   });
+  console.log(guildMemberData);
   return (
     <div className="flex flex-col w-[67%] self-center gap-8">
       <p className="text-4xl font-bold text-neutral-900">멤버</p>

--- a/src/app/guild/[guildid]/page.tsx
+++ b/src/app/guild/[guildid]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import PlayOnRollingBanner from '@/components/common/play-on-rolling-banner';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import { Suspense, useEffect, useState } from 'react';
 import GuildInfoSection from './components/GuildInfoSection';
 import GuildInfoSectionSkeleton from './components/GuildInfoSectionSkeleton';

--- a/src/app/guild/create/page.tsx
+++ b/src/app/guild/create/page.tsx
@@ -37,10 +37,12 @@ const createGuildFormSchema = z.object({
     .number()
     .min(2, { message: '길드 최대 인원은 2명 이상부터 가능합니다.' })
     .max(50, { message: '길드 최대 인원은 50명까지 가능합니다.' }),
-  game: z.object({
-    appid: z.number().min(1),
-    name: z.string().min(1),
-  }),
+  game: z
+    .object({
+      appid: z.number().min(1),
+      name: z.string().min(1),
+    })
+    .nullish(),
   partyStyle: z.array(z.string()),
   skillLevel: z.array(z.string()),
   gender: z.array(z.string()),
@@ -205,8 +207,8 @@ export default function GuildCreate() {
       name: data.name,
       description: data.desc,
       maxMembers: data.limit_people,
-      // appid: data.game?.appid ? data.game?.appid : null,
-      appid: data.game.appid || null,
+      appid: data.game?.appid ? data.game?.appid : null,
+      // appid: data.game.appid || null,
       isPublic: data.public,
       fileType: data.fileType as FileType,
       tags: tagList,

--- a/src/app/guild/page.tsx
+++ b/src/app/guild/page.tsx
@@ -36,7 +36,7 @@ export default function Guild() {
   });
 
   const handleSearch = (value: string) => {
-    router.push(`${PATH.guild_list}?keyword=${value}`);
+    router.push(`${PATH.guild_list}?name=${value}`);
   };
 
   const dummyGameList: gameSimple[] = Array(4).fill(dummyGameSimple);

--- a/src/app/guild/test/page.tsx
+++ b/src/app/guild/test/page.tsx
@@ -1,16 +1,18 @@
 'use client';
 
 import { useGuild } from '@/api/guild';
+import { useGuildsMembers } from '@/api/guild-member';
 import { useGuildBoard } from '@/api/guildBoard';
 import { useGuildJoin } from '@/api/guildJoin';
 import UserApprove from '@/app/party/components/UserApprove';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { AdditionalInfo, GuildCreateRequest, GuildLIstRequest, GuildUpdateRequest } from '@/types/guildApi';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useCallback, useState } from 'react';
 
 export default function Test() {
   const Guild = useGuild();
+  const guildMembers = useGuildsMembers();
   const [image, setImage] = useState<File | null>(null);
   const [data, setData] = useState<AdditionalInfo[]>();
 
@@ -167,6 +169,12 @@ export default function Test() {
     console.log(response);
   };
 
+  const leaveGuild = useCallback(async () => {
+    const response = await guildMembers.LeaveMembers('16');
+    console.log(response);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <div className="wrapper mt-32 mb-32">
       <Input type="file" onChange={handleChange} className="w-[500px]" />
@@ -207,6 +215,7 @@ export default function Test() {
             <Button onClick={createComment}> 40번 게시글 댓글 작성</Button>
             <Button onClick={updateComment}> 40번 게시글 36번 댓글 수정</Button>
             <Button onClick={deleteComment}> 40번 게시글 36번 댓글 삭제</Button>
+            <Button onClick={leaveGuild}> 16번 길드 탈퇴</Button>
           </div>
         </div>
       </div>

--- a/src/components/guild/guild-we-need-you.tsx
+++ b/src/components/guild/guild-we-need-you.tsx
@@ -3,14 +3,16 @@
 import { guild } from '@/types/guild';
 import RetroButton from '../common/RetroButton';
 import CapsuleCategoryMenu from '@/components/common/capsule-category-menu';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import UserInfoHorizontal from '@/app/party/components/UserInfoHorizontal';
 import Tag from '../common/Tag';
-import { communityTags, guildCommunityTags } from '@/types/Tags/communityTags';
+import { guildCommunityTags } from '@/types/Tags/communityTags';
 import SearchBar from '../common/SearchBar';
 import Link from 'next/link';
 import { GUILD_ROUTE } from '@/constants/routes/guild';
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
+import { PATH } from '@/constants/routes';
+import { Home } from 'lucide-react';
 
 type WeNeedYouProps = {
   guildData: guild;
@@ -18,7 +20,6 @@ type WeNeedYouProps = {
 };
 
 export default function WeNeedYou(props: WeNeedYouProps) {
-  const [query, setQuery] = useState('');
   const params = useParams();
   const guildId = (params.guildid as string) ?? null;
   const router = useRouter();
@@ -52,9 +53,14 @@ export default function WeNeedYou(props: WeNeedYouProps) {
   return (
     <div className={`flex flex-col p-8 gap-9 rounded-xl border border-neutral-200 bg-white ${props.className} `}>
       <div className="flex flex-col gap-5 ">
-        <Tag size="small" style="default" background="medium" className="w-12 font-suit font-bold">
-          길드장
-        </Tag>
+        <div className="flex justify-between items-center">
+          <Tag size="small" style="default" background="medium" className="w-12 font-suit font-bold">
+            길드장
+          </Tag>
+          <div onClick={() => router.push(PATH.guild_detail(guildId))}>
+            <Home className="size-5 hover:text-purple-500 text-neutral-400 cursor-pointer" />
+          </div>
+        </div>
         <UserInfoHorizontal size="small" data={props.guildData.owner} />
         <p className="font-dgm line-clamp-1 text-ellipsis overflow-hidden text-neutral-900 text-4xl">
           {props.guildData.guild_name}

--- a/src/components/guildUser/GuildUser.tsx
+++ b/src/components/guildUser/GuildUser.tsx
@@ -6,7 +6,7 @@ import { useMemo } from 'react';
 
 interface guildUserProps {
   data: guildUser;
-  membetId: string;
+  memberId: string;
   index: number;
   total: number;
   onToggleManager: (userId: string, guild_role: string) => void;
@@ -15,7 +15,7 @@ interface guildUserProps {
 
 export default function GuildUser(props: guildUserProps) {
   const { data, index, total, onToggleManager, onKickMember } = props;
-  const joindDate = data.joined_at
+  const joinedDate = data.joined_at
     ? new Date(data.joined_at).toLocaleDateString('ko-kr', { year: 'numeric', month: 'long', day: 'numeric' })
     : '정보 없음';
 
@@ -30,7 +30,7 @@ export default function GuildUser(props: guildUserProps) {
     <>
       <div className="flex gap-6 py-8">
         <Avatar className="bg-neutral-400 w-16 h-16">
-          <AvatarImage src={data.user.img_src || '/img/dummy_profile.jpg'} />
+          <AvatarImage src={data.user.img_src || '/img/dummy_profile.jpg'} className="object-cover" />
         </Avatar>
 
         <div className="w-full">
@@ -39,7 +39,7 @@ export default function GuildUser(props: guildUserProps) {
           <div className="flex gap-5">
             <div className="flex">
               <p className="font-suit text-base font-medium">길드 가입일 : </p> &nbsp;
-              <p className="font-suit text-base font-medium text-neutral-500">{joindDate}</p>
+              <p className="font-suit text-base font-medium text-neutral-500">{joinedDate}</p>
             </div>
 
             <div className="flex">

--- a/src/components/guildUser/GuildUserCard.tsx
+++ b/src/components/guildUser/GuildUserCard.tsx
@@ -52,7 +52,7 @@ export default function GuildUserCard(props: guildUserCardProps2) {
           </div>
           <div>
             {data.title && <p className="font-suit text-sm font-normal text-neutral-500">{data.title}</p>}
-            <p className="font-suit text-xl font-medium">{data.username}</p>
+            <p className="font-suit text-xl font-medium">{data.nickname}</p>
             {data.joined_at && <p className="font-suit text-sm font-normal text-neutral-500">가입일 : {joinedDate}</p>}
           </div>
         </div>

--- a/src/components/guildUser/GuildUserCard.tsx
+++ b/src/components/guildUser/GuildUserCard.tsx
@@ -46,7 +46,7 @@ export default function GuildUserCard(props: guildUserCardProps2) {
         <div className="flex gap-5">
           <div className="w-16 h-16 aspect-square relative ">
             <Avatar className="bg-neutral-400 w-16 h-16">
-              <AvatarImage src={data.img_src} className="" />
+              <AvatarImage src={data.img_src} className="object-cover" />
             </Avatar>
             {badge}
           </div>

--- a/src/types/guild.ts
+++ b/src/types/guild.ts
@@ -28,6 +28,7 @@ export interface guildUser {
 
 export interface guildUserSimple {
   username: string;
+  nickname: string;
   title: string | null;
   role: string;
   img_src: string;

--- a/src/types/guildApi.ts
+++ b/src/types/guildApi.ts
@@ -71,6 +71,7 @@ export interface GuildDetailMember {
   title: string;
   role: string;
   joinedAt: string;
+  nickname: string;
 }
 
 export interface GuildJoinRequest {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용


- 길드 메인 페이지 검색 라우팅 적용
- 길드 상세 태그 자르기
- 길드 게시판 글 작성시 운영진 아니면 공지 작성 막기
- 길드 게시판 글 상세에서 내가 좋아요 눌렀을 때 페이지 나갔다 들어와도 토글 on 처리
- 길드 커뮤니티에서 길드 상세로 이동 버튼 추가
- 길드 탈퇴 구현 (방장은 일단 탈퇴 못하게 해뒀습니다. 리더 권한 넘기는 기능이 없으므로)
- GET /api/guilds/list -> guildname에 gamename 들어가는 문제 해결 요청
- 길드 상세 username -> nickname
- 길드 생성 시 게임 옵셔널 처리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
