### PR TITLE
feat: dompurify 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "^3.6.0",
+        "dompurify": "^3.2.5",
         "dotenv": "^16.4.7",
         "embla-carousel-autoplay": "^8.5.2",
         "embla-carousel-react": "^8.5.2",
@@ -2087,6 +2088,13 @@
         "meshoptimizer": "~0.18.1"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/webxr": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.21.tgz",
@@ -3644,6 +3652,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.5.tgz",
+      "integrity": "sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^3.6.0",
+    "dompurify": "^3.2.5",
     "dotenv": "^16.4.7",
     "embla-carousel-autoplay": "^8.5.2",
     "embla-carousel-react": "^8.5.2",

--- a/src/app/community/[postId]/page.tsx
+++ b/src/app/community/[postId]/page.tsx
@@ -12,13 +12,14 @@ import { PATH } from '@/constants/routes';
 import { useToast } from '@/hooks/use-toast';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Eye, SquarePen, ThumbsUp, Trash2 } from 'lucide-react';
+import { Eye, ThumbsUp, Trash2 } from 'lucide-react';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import styles from './freeCommunityDetail.module.css';
 import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form';
+import SafeHtml from '@/components/common/SafeHtml';
 
 const commentSchema = z.object({
   comment: z.string().min(1, { message: '댓글을 입력해주세요' }),
@@ -146,7 +147,7 @@ export default function Community() {
                   />
                 </div>
               )}
-              <div className={`${styles.ql}`} dangerouslySetInnerHTML={{ __html: postData.content }} />
+              <SafeHtml html={postData.content} className={`${styles.ql}`} />
               <div className="flex justify-end gap-2">
                 <Toggle
                   variant="outline"

--- a/src/app/game/[gameid]/gameDetail.module.css
+++ b/src/app/game/[gameid]/gameDetail.module.css
@@ -1,0 +1,61 @@
+.ql h1 {
+  font-size: 2.25rem; /* text-4xl */
+  font-weight: 600; /* font-extrabold */
+  margin-top: 1rem; /* mt-4 */
+  margin-bottom: 0.5rem; /* mb-2 */
+}
+
+.ql h2 {
+  font-size: 1.875rem; /* text-3xl */
+  font-weight: 500; /* font-bold */
+  margin-top: 1rem; /* mt-4 */
+  margin-bottom: 0.5rem; /* mb-2 */
+}
+
+.ql h3 {
+  font-size: 1.5rem; /* text-2xl */
+  font-weight: 400; /* font-semibold */
+  margin-top: 1rem; /* mt-4 */
+  margin-bottom: 0.5rem; /* mb-2 */
+}
+
+.ql h4 {
+  font-size: 1.25rem; /* text-xl */
+  font-weight: 400; /* font-medium */
+  margin-top: 0.75rem; /* mt-3 */
+  margin-bottom: 0.5rem; /* mb-2 */
+}
+
+.ql blockquote {
+  padding-left: 1rem; /* pl-4 */
+  border-left: 4px solid #9ca3af; /* border-gray-400 */
+  font-style: italic;
+  color: #4b5563; /* text-gray-600 */
+  margin-top: 1rem; /* my-4 */
+  margin-bottom: 1rem;
+}
+
+.ql li[data-list='ordered'] {
+  list-style-type: decimal;
+  margin-left: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+.ql li[data-list='bullet'] {
+  list-style-type: disc;
+  margin-left: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.ql img {
+  margin: 8px 0px;
+  width: 100%;
+}
+
+.ql p {
+  font-size: 16px;
+}
+
+.ql b {
+  font-size: 28px;
+  font-weight: 500;
+}

--- a/src/app/game/[gameid]/page.tsx
+++ b/src/app/game/[gameid]/page.tsx
@@ -20,6 +20,8 @@ import { gameDetail } from '@/types/games';
 import { getPartyRes } from '@/types/party';
 import Link from 'next/link';
 import { PARTY_ROUTE } from '@/constants/routes/party';
+import SafeHtml from '@/components/common/SafeHtml';
+import styles from './gameDetail.module.css';
 
 export default function GameDetail({ params }: { params: { gameid: string } }) {
   const [selectedSlide, setSelectedSlide] = useState(0);
@@ -164,6 +166,7 @@ export default function GameDetail({ params }: { params: { gameid: string } }) {
       };
     },
   });
+  // console.log('gameDetails', gameDetails);
   // const dummyReviewData = {
   //   query_summary: {
   //     num_reviews: 3,
@@ -348,7 +351,7 @@ export default function GameDetail({ params }: { params: { gameid: string } }) {
                 <p className="text-xl font-bold">이 게임에 대해서</p>
               </AccordionTrigger>
               <AccordionContent>
-                <div dangerouslySetInnerHTML={{ __html: gameDetails ? gameDetails.game.about : '' }}></div>
+                <SafeHtml html={gameDetails ? gameDetails.game.about : ''} className={`${styles.ql}`} />
               </AccordionContent>
             </AccordionItem>
             <AccordionItem value="item-2">
@@ -356,7 +359,7 @@ export default function GameDetail({ params }: { params: { gameid: string } }) {
                 <p className="text-xl font-bold">상세 정보</p>
               </AccordionTrigger>
               <AccordionContent>
-                <div dangerouslySetInnerHTML={{ __html: gameDetails ? gameDetails.game.detail_desc : '' }}></div>
+                <SafeHtml html={gameDetails ? gameDetails.game.detail_desc : ''} className={`${styles.ql}`} />
               </AccordionContent>
             </AccordionItem>
             {/* <AccordionItem value="item-3">

--- a/src/app/guild/[guildid]/community/[postid]/page.tsx
+++ b/src/app/guild/[guildid]/community/[postid]/page.tsx
@@ -13,13 +13,14 @@ import { Toggle } from '@/components/ui/toggle';
 import { PATH } from '@/constants/routes';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Eye, SquarePen, ThumbsUp, Trash2 } from 'lucide-react';
+import { Eye, ThumbsUp, Trash2 } from 'lucide-react';
 import { useParams, useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import styles from './guildCommunityDetail.module.css';
 import { useCallback, useEffect, useState } from 'react';
 import { useToast } from '@/hooks/use-toast';
+import SafeHtml from '@/components/common/SafeHtml';
 
 const commentSchema = z.object({
   comment: z.string().min(1, { message: '댓글을 입력해주세요' }),
@@ -149,7 +150,8 @@ export default function GuildCommunityDetail() {
                 />
               </div>
             )}
-            <div className={`${styles.ql}`} dangerouslySetInnerHTML={{ __html: postData.content }} />
+            {/* <div className={`${styles.ql}`} dangerouslySetInnerHTML={{ __html: postData.content }} /> */}
+            <SafeHtml html={postData.content} className={`${styles.ql}`} />
             <div className="flex justify-end gap-2">
               <Toggle
                 variant="outline"

--- a/src/components/common/SafeHtml.tsx
+++ b/src/components/common/SafeHtml.tsx
@@ -1,0 +1,9 @@
+import DOMPurify from 'dompurify';
+
+export default function SafeHtml({ html, className }: { html: string; className?: string }) {
+  const safeHtml = DOMPurify.sanitize(html, {
+    ADD_TAGS: ['iframe'],
+    ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder', 'scrolling'],
+  });
+  return <div className={className} dangerouslySetInnerHTML={{ __html: safeHtml }} />;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#278

## 📝작업 내용

-  `dangerouslySetInnerHTML` 을 사용하고 있는 게임 상세 페이지와, 커뮤니티(길드,자유) 상세 페이지에 DOMpurify 라이브러리를 사용하여 만든 `SafeHtml` 컴포넌트를 적용시켰습니다.
- 추가로 게임 상세 페이지의 html에 css를 적용시켜 주었습니다. (gameDetail.module.css)
    - 이미지 너비 100%, 이미지 상하 마진, h1~h4 태그 스타일 등등
 
![image](https://github.com/user-attachments/assets/914b7916-375e-47bc-9e62-5a1e160d87e5)


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
